### PR TITLE
[WF-205] Add necessary github and md files for the repo

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,32 @@
+settings:
+  # Jira project key to create the issue in
+  jira_project_key: "WF"
+
+  # Dictionary mapping GitHub issue status to Jira issue status
+  status_mapping:
+    opened: Untriaged
+    closed: Done
+
+  # (Optional) GitHub labels. Only issues with one of those labels will be synchronized.
+  # If not specified, all issues will be synchronized
+  labels:
+    - bug
+    - enhancement
+
+  # (Optional) (Default: false) Add a new comment in GitHub with a link to Jira created issue
+  add_gh_comment: true
+
+  # (Optional) (Default: true) Synchronize issue description from GitHub to Jira
+  sync_description: true
+
+  # (Optional) (Default: true) Synchronize comments from GitHub to Jira
+  sync_comments: false
+
+  # (Optional) (Default: None) Parent Epic key to link the issue to
+  epic_key: "WF-63"
+
+  # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
+  # If label on the issue is not in specified list, this issue will be created as a Bug
+  label_mapping:
+    enhancement: Story
+    bug: Bug

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,56 @@
+name: Bug Report
+description: File a bug report
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this bug report! Before submitting your issue, please make
+        sure you are using the latest version of the charm. If not, please switch to this image prior to 
+        posting your report to make sure it's not already solved.
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: Bug Description
+      description: >
+        If applicable, add screenshots to help explain the problem you are facing.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: To Reproduce
+      description: >
+        Please provide a step-by-step instruction of how to reproduce the behavior.
+      placeholder: |
+        1. `juju deploy ...`
+        2. `juju relate ...`
+        3. `juju status --relations`
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        We need to know a bit more about the context in which you run the charm.
+        - Are you running Juju locally, on lxd, in multipass or on some other platform?
+        - What track and channel you deployed the charm from (ie. `latest/edge` or similar).
+        - Version of any applicable components, like the juju snap, the model controller, lxd, microk8s, and/or multipass.
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: >
+        Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+        Fetch the logs using `juju debug-log --replay` and `kubectl logs ...`. Additional details available in the juju docs 
+        at https://documentation.ubuntu.com/juju/latest/howto/manage-logs/
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context

--- a/.github/ISSUE_TEMPLATE/enhancement_proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/enhancement_proposal.yaml
@@ -1,0 +1,33 @@
+name: Enhancement Proposal
+description: File an enhancement proposal
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thanks for taking the time to fill out this enhancement proposal! Before submitting your issue, please make
+        sure there isn't already a prior issue concerning this. If there is, please join that discussion instead.
+  - type: textarea
+    id: problem-statement
+    attributes:
+      label: Problem statement
+      description: >
+        State the problem and motivations with as much detail as possible.
+    validations:
+      required: true
+  - type: textarea
+    id: enhancement-proposal
+    attributes:
+      label: Enhancement Proposal
+      description: >
+        Describe the enhancement you would like to see that solves the problem stated before.
+    validations:
+      required: true
+  - type: textarea
+    id: what-needs-to-get-done
+    attributes:
+      label: What needs to get done?
+      description: >
+        Please provide a list of actions that need to get done for this enhancement.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Description
+<!-- Summary of the changes in this PR -->
+
+<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
+
+---
+## Testing instructions
+<!-- Steps to manually test the changes and the expected results, only if applicable -->
+<!-- Example:
+1. Build charm
+2. Configure X with abc value
+3. Integrate with Y charm
+-->
+
+## Notes for Reviewers (optional)
+<!-- Any specific areas to focus on, known issues, or extra context -->
+
+---
+## Checklist (all that apply)
+- [ ] Unit tests added or updated
+- [ ] Integration tests added or updated
+- [ ] Documentation updated

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+venv/
+build/
+*.charm
+.tox/
+.coverage
+__pycache__/
+*.py[cod]
+.idea
+.vscode
+src/*.egg-info/
+uv.lock.bak

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/workflows

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# airflow-coordinator-k8s-operator
+# Airflow Coordinator K8s Operator
+
 A Charmed Operator for coordinating Charmed Airflow operators 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+The easiest way to report a security issue is through a [Github Private Security Report](https://github.com/canonical/airflow-coordinator-k8s-operator/security/advisories/new) with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+Alternatively, to report a security issue via email, please email [security@ubuntu.com](mailto:security@ubuntu.com) with a description of the issue, the steps you took to create the issue, affected versions, and, if known, mitigations for the issue.
+
+The [Ubuntu Security disclosure and embargo policy](https://ubuntu.com/security/disclosure-policy) contains more information about what you can expect when you contact us and what we expect from you.


### PR DESCRIPTION
Add all necessary files to onboard repo:
1. github issue templates (for both bug reports and enhancement requests)
2. github pull request template
3. github jira sync configuration
4. a minimal gitignore file for a python project
5. codeowners pointing to the workflows team for all files
6. a simple empty readme
7. a markdown file outlining the security policy