### PR TITLE
Modify AirflowCoordinatorRequires methods to check for relation existence

### DIFF
--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -652,6 +652,10 @@ class AirflowCoordinatorRequires(ops.Object):
         workload_container: ops.Container,
         callback: typing.Callable,
     ):
+        self._charm = charm
+        self._component = component
+        self._relation_name = relation_name
+
         if not charm.model.get_relation(relation_name):
             return
 
@@ -660,10 +664,6 @@ class AirflowCoordinatorRequires(ops.Object):
         self._requirer_handler = AirflowCoordinatorRequirerEventHandler(
             charm, relation_name, AirflowCoordinatorProviderModel
         )
-
-        self._charm = charm
-        self._component = component
-        self._relation_name = relation_name
 
         self._workload_container = workload_container
 
@@ -690,14 +690,15 @@ class AirflowCoordinatorRequires(ops.Object):
             self.framework.observe(event, callback)
 
     @property
-    def ready(self) -> bool:
+    def _ready(self) -> bool:
         """Indicates whether relation is ready, config available and workload can be started."""
-        return (
-            not self.missing_core_components_exist
-            and not self.validation_failure_messages
-            and self._requirer_handler.provider_content
-            and self._requirer_handler.provider_content.config_template
-        )
+        return all([
+            self._charm.model.get_relation(self._relation_name),
+            not self.missing_core_components_exist,
+            not self.validation_failure_messages,
+            self._requirer_handler.provider_content,
+            self._requirer_handler.provider_content.config_template,
+        ])
 
     @property
     def airflow_core_validation_failures(self) -> list[str]:
@@ -732,8 +733,7 @@ class AirflowCoordinatorRequires(ops.Object):
         """
         return (
             self._workload_container.can_connect()
-            and self._charm.model.get_relation(self._relation_name)
-            and self.ready
+            and self._ready
         )
 
     def write_airflow_config(self, config_path: str) -> None:
@@ -764,8 +764,7 @@ class AirflowCoordinatorRequires(ops.Object):
         """
         return (
             self._workload_container.can_connect()
-            and self._charm.model.get_relation(self._relation_name)
-            and self.ready
+            and self._ready
             and self._requirer_handler.provider_content.kubernetes_executor_pod_spec
         )
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Modify charm lib `AirflowCoordinatorRequires` to ensure methods can be invoked even if relation to coordinator does not exist in consuming core charms.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
