### PR TITLE
feat: run airflow db migrate command

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -42,6 +42,16 @@ provides:
   airflow-coordinator:
     interface: airflow_coordinator
 
+containers:
+  airflow-coordinator:
+    resource: airflow-coordinator-image
+
+resources:
+  airflow-coordinator-image:
+    type: oci-image
+    description: Airflow workload container for running commands
+    upstream-source: ubuntu/airflow:3.1-24.04_edge
+
 requires:
   postgres:
     interface: postgresql_client

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -55,3 +55,7 @@ resources:
 requires:
   postgres:
     interface: postgresql_client
+
+peers:
+  coordinator-peers:
+    interface: coordinator_peers

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -128,6 +128,44 @@ LIBPATCH = 1
 logger = logging.getLogger(__name__)
 
 
+def write_airflow_config(
+    container: ops.Container,
+    config_path: str,
+    config_template: str,
+    sensitive_data: dict[str, str],
+) -> None:
+    """Render and write the Airflow config to a container.
+
+    This utility function can be used by both the coordinator charm (for db migrations)
+    and core charms (for their workload configuration).
+
+    Args:
+        container: The Pebble container to write the config to.
+        config_path: Path where the config file will be written.
+        config_template: The Jinja2 template string for the Airflow config.
+        sensitive_data: Dictionary of sensitive values to render in the template.
+
+    Raises:
+        RuntimeError: If unable to connect to the container or write the config.
+    """
+    if not container.can_connect():
+        raise RuntimeError("Cannot connect to workload container")
+
+    try:
+        config = jinja2.Environment().from_string(config_template).render(**sensitive_data)
+
+        container.push(
+            config_path,
+            config,
+            user="root",
+            group="root",
+            make_dirs=True,
+        )
+        logger.info(f"Successfully wrote Airflow config to {config_path}")
+    except Exception as e:
+        raise RuntimeError(f"Failed to write Airflow config: {e}") from e
+
+
 class AirflowCoreComponentEnum(str, enum.Enum):
     """Enum to encapsulate the possible Airflow core component options."""
 
@@ -784,18 +822,11 @@ class AirflowCoordinatorRequires(ops.Object):
         """Render the Airflow config in the provided path in the workload container."""
         provider_content = self._requirer_handler.provider_content
 
-        config = (
-            jinja2.Environment()
-            .from_string(provider_content.config_template)
-            .render(**json.loads(provider_content.sensitive_data))
-        )
-
-        self._workload_container.push(
+        write_airflow_config(
+            self._workload_container,
             config_path,
-            config,
-            user="root",
-            group="root",
-            make_dirs=True,
+            provider_content.config_template,
+            json.loads(provider_content.sensitive_data),
         )
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -35,13 +35,8 @@ class ExceptionWithStatusError(Exception):
 class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
     """Charm the application."""
 
-    _stored = ops.StoredState()
-
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
-
-        # StoredState to save state of db migration command
-        self._stored.set_default(db_migration_ran=False)
 
         self._container = self.unit.get_container(constants.WORKLOAD_CONTAINER_NAME)
         self._config_generator = config_generator.AirflowConfigGenerator(self)
@@ -112,6 +107,31 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
             },
         }
         return layer
+
+    @property
+    def _peer_relation(self) -> ops.Relation:
+        """Return the peer relation.
+
+        Raises:
+            ExceptionWithStatusError: If peer relation is not available.
+        """
+        peer_relation = self.model.get_relation(constants.PEER_RELATION_NAME)
+        if not peer_relation:
+            raise ExceptionWithStatusError(
+                constants.WAITING_FOR_PEER_RELATION_MESSAGE, ops.WaitingStatus
+            )
+        return peer_relation
+
+    @property
+    def _db_migration_ran(self) -> bool:
+        """Check if database migration has been run."""
+        return self._peer_relation.data[self.app].get("db_migration_ran") == "true"
+
+    @_db_migration_ran.setter
+    def _db_migration_ran(self, value: bool) -> None:
+        """Set database migration state."""
+        # We need to cast the bool to str, Juju relation data bags can only store strings
+        self._peer_relation.data[self.app]["db_migration_ran"] = str(value).lower()
 
     def _required_dependencies_exist(self) -> bool:
         """Returns whether all required dependencies for the coordinator exist."""
@@ -209,10 +229,12 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
             self._configure_pebble_layer()
             self._write_airflow_config()
 
-            # Use StorageState to track if db migration has run before
-            if self._stored.db_migration_ran is False:
+            # Use peer relation data to track if db migration has run
+            # TODO: once we have upgrade logic, we'll need to change the
+            # conditions under which this state will be True/False.
+            if not self._db_migration_ran:
                 self._run_db_migrate()
-                self._stored.db_migration_ran = True
+                self._db_migration_ran = True
 
             self._config_provider.set_airflow_config(
                 self._config_generator.config_template,

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,7 +9,9 @@ import logging
 import charms.airflow_coordinator_k8s.v0.airflow_coordinator as airflow_coordinator
 import charms.data_platform_libs.v0.data_interfaces as data_interfaces_v0
 import ops
+from ops.pebble import LayerDict
 
+import command_executor
 import config_generator
 import constants
 
@@ -33,13 +35,22 @@ class ExceptionWithStatusError(Exception):
 class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
     """Charm the application."""
 
+    _stored = ops.StoredState()
+
     def __init__(self, framework: ops.Framework):
         super().__init__(framework)
 
+        # StoredState to save state of db migration command
+        self._stored.set_default(db_migration_ran=False)
+
+        self._container = self.unit.get_container(constants.WORKLOAD_CONTAINER_NAME)
         self._config_generator = config_generator.AirflowConfigGenerator(self)
+        self._command_executor = command_executor.CommandExecutor(self._container)
 
         self._database_requires = data_interfaces_v0.DatabaseRequires(
-            self, constants.POSTGRES_RELATION_NAME, database_name=constants.AIRFLOW_DATABASE_NAME
+            self,
+            constants.POSTGRES_RELATION_NAME,
+            database_name=constants.AIRFLOW_DATABASE_NAME,
         )
         self._config_provider = airflow_coordinator.AirflowCoordinatorProvides(
             self,
@@ -51,6 +62,7 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
         for event in [
             self.on.start,
             self.on.update_status,
+            self.on[constants.WORKLOAD_CONTAINER_NAME].pebble_ready,
             self._database_requires.on.database_created,
             self._database_requires.on.endpoints_changed,
             self.on[constants.POSTGRES_RELATION_NAME].relation_broken,
@@ -73,6 +85,34 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
             for field in ["username", "password", "endpoints", "database"]
         )
 
+    @property
+    def _airflow_coordinator_layer(self) -> LayerDict:
+        """Return the service Pebble layer."""
+        # Pebble layer to disable the default airflow service and health check from the rock.
+        # The rock runs "airflow standalone" by default with an "airflow-running" health check,
+        # but the coordinator only needs to run "airflow db migrate" and should not run
+        # the service.
+        layer: LayerDict = {
+            "summary": "Airflow coordinator layer",
+            "description": "Pebble layer for Airflow coordinator to run db migrations",
+            "services": {
+                "airflow": {
+                    "override": "merge",
+                    "startup": "disabled",
+                }
+            },
+            "checks": {
+                "airflow-running": {
+                    "override": "replace",
+                    "level": "alive",
+                    "exec": {
+                        "command": "/bin/true",
+                    },
+                }
+            },
+        }
+        return layer
+
     def _required_dependencies_exist(self) -> bool:
         """Returns whether all required dependencies for the coordinator exist."""
         # TODO: add k8s executor configurator relation here too
@@ -84,6 +124,11 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
 
     def _perform_checks(self) -> None:
         """Checks to ensure the charm is able to generate and distribute configs."""
+        if not self._container.can_connect():
+            raise ExceptionWithStatusError(
+                constants.WAITING_FOR_CONTAINER_MESSAGE, ops.WaitingStatus
+            )
+
         if not self.model.get_relation(constants.POSTGRES_RELATION_NAME):
             self._config_provider.set_validation_errors()
             raise ExceptionWithStatusError(
@@ -125,13 +170,49 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
                 constants.MISMATCHED_WORKLOAD_IMAGE_HASHES_MESSAGE, ops.BlockedStatus
             )
 
-    def _reconcile(self, _) -> None:
+    def _configure_pebble_layer(self) -> None:
+        """Configure the Pebble layer to disable the default airflow service.
+
+        The rock image runs 'airflow standalone' by default, but the coordinator
+        only needs to run 'airflow db migrate'. This method disables the default
+        service to ensure Airflow components are not running during migration.
+        """
+        self._container.add_layer(
+            "airflow-coordinator", self._airflow_coordinator_layer, combine=True
+        )
+        self._container.replan()
+
+    def _write_airflow_config(self) -> None:
+        """Write the Airflow configuration file to the container."""
+        airflow_coordinator.write_airflow_config(
+            self._container,
+            constants.AIRFLOW_CONFIG_PATH,
+            self._config_generator.config_template,
+            self._config_generator.sensitive_config_values,
+        )
+
+    def _run_db_migrate(self) -> None:
+        """Run database migration in the workload container."""
+        result = self._command_executor.run_db_migrate()
+        if not result.success:
+            raise ExceptionWithStatusError(
+                constants.DB_MIGRATION_FAILED_MESSAGE, ops.BlockedStatus
+            )
+
+    def _reconcile(self, event: ops.EventBase) -> None:
         """Idempotent reconcile method to handle most relevant charm events."""
         if not self.unit.is_leader():
             return
 
         try:
             self._perform_checks()
+            self._configure_pebble_layer()
+            self._write_airflow_config()
+
+            # Use StorageState to track if db migration has run before
+            if self._stored.db_migration_ran is False:
+                self._run_db_migrate()
+                self._stored.db_migration_ran = True
 
             self._config_provider.set_airflow_config(
                 self._config_generator.config_template,
@@ -140,6 +221,10 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
         except ExceptionWithStatusError as e:
             logger.error(e)
             self.unit.status = e.status
+            return
+        except command_executor.CommandExecutionError as e:
+            logger.error(e)
+            self.unit.status = ops.BlockedStatus(e.message)
             return
 
         self.unit.status = ops.ActiveStatus()

--- a/src/command_executor.py
+++ b/src/command_executor.py
@@ -1,0 +1,91 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Command execution support for the Airflow Coordinator charm."""
+
+import logging
+import typing
+
+import ops
+
+logger = logging.getLogger(__name__)
+
+
+class CommandExecutionError(Exception):
+    """Exception raised when command execution fails."""
+
+    def __init__(
+        self, message: str, return_code: int | None = None, stderr: str | None = None
+    ):
+        super().__init__(message)
+        self.message = message
+        self.return_code = return_code
+        self.stderr = stderr
+
+
+class CommandExecutionResult(typing.NamedTuple):
+    """Result of a command execution."""
+
+    success: bool
+    stdout: str
+    stderr: str
+    return_code: int | None
+
+
+class CommandExecutor:
+    """Handles command execution in the workload container."""
+
+    def __init__(self, container: ops.Container):
+        """Initialize the command executor.
+
+        Args:
+            container: The Pebble container to execute commands in.
+        """
+        self._container = container
+
+    def run_db_migrate(self) -> CommandExecutionResult:
+        """Execute the 'airflow db migrate' command.
+
+        Returns:
+            CommandExecutionResult with execution details.
+
+        Raises:
+            CommandExecutionError: If unable to connect to the container.
+        """
+        if not self._container.can_connect():
+            raise CommandExecutionError("Cannot connect to workload container")
+
+        logger.info("Executing 'airflow db migrate' command")
+
+        try:
+            process = self._container.exec(
+                ["airflow", "db", "migrate"],
+                environment={
+                    "AIRFLOW_HOME": "/",
+                    "AIRFLOW__CORE__DAGS_FOLDER": "/dags",
+                },
+            )
+            stdout, stderr = process.wait_output()
+
+            logger.info("'airflow db migrate' completed successfully")
+            return CommandExecutionResult(
+                success=True,
+                stdout=stdout or "",
+                stderr=stderr or "",
+                return_code=0,
+            )
+        except ops.pebble.ExecError as e:
+            logger.error(
+                f"'airflow db migrate' failed with exit code {e.exit_code}: {e.stderr}"
+            )
+            return CommandExecutionResult(
+                success=False,
+                stdout=e.stdout or "",
+                stderr=e.stderr or "",
+                return_code=e.exit_code,
+            )
+        except Exception as e:
+            logger.error(f"Unexpected error executing 'airflow db migrate': {e}")
+            raise CommandExecutionError(
+                f"Failed to execute 'airflow db migrate': {e}"
+            ) from e

--- a/src/constants.py
+++ b/src/constants.py
@@ -8,9 +8,22 @@ AIRFLOW_COORDINATOR_RELATION_NAME = "airflow-coordinator"
 POSTGRES_RELATION_NAME = "postgres"
 AIRFLOW_DATABASE_NAME = "airflow"
 
+WORKLOAD_CONTAINER_NAME = "airflow-coordinator"
+AIRFLOW_CONFIG_PATH = "/airflow.cfg"
+
 MISSING_POSTGRES_INTEGRATION_MESSAGE = "Missing integration with postgres"
-WAITING_FOR_DATABASE_TO_BE_CREATED_MESSAGE = "Waiting for airflow database to be created"
-WAITING_FOR_DATABASE_CONNECTION_MESSAGE = "Waiting for database connection info from postgres"
+WAITING_FOR_DATABASE_TO_BE_CREATED_MESSAGE = (
+    "Waiting for airflow database to be created"
+)
+WAITING_FOR_DATABASE_CONNECTION_MESSAGE = (
+    "Waiting for database connection info from postgres"
+)
+WAITING_FOR_CONTAINER_MESSAGE = "Waiting for workload container"
+DB_MIGRATION_FAILED_MESSAGE = "Database migration failed"
 MISMATCHED_AIRFLOW_VERSIONS_MESSAGE = "Integrated apps with mismatched airflow versions"
-MISMATCHED_WORKLOAD_IMAGE_HASHES_MESSAGE = "Integrated apps with mismatched workload image hashes"
-MISSING_INTEGRATIONS_MESSAGE_TEMPLATE = "Missing integrations with: {missing_core_components}"
+MISMATCHED_WORKLOAD_IMAGE_HASHES_MESSAGE = (
+    "Integrated apps with mismatched workload image hashes"
+)
+MISSING_INTEGRATIONS_MESSAGE_TEMPLATE = (
+    "Missing integrations with: {missing_core_components}"
+)

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,6 +5,8 @@
 
 AIRFLOW_COORDINATOR_RELATION_NAME = "airflow-coordinator"
 
+PEER_RELATION_NAME = "coordinator-peers"
+
 POSTGRES_RELATION_NAME = "postgres"
 AIRFLOW_DATABASE_NAME = "airflow"
 
@@ -19,6 +21,7 @@ WAITING_FOR_DATABASE_CONNECTION_MESSAGE = (
     "Waiting for database connection info from postgres"
 )
 WAITING_FOR_CONTAINER_MESSAGE = "Waiting for workload container"
+WAITING_FOR_PEER_RELATION_MESSAGE = "Waiting for peer relation"
 DB_MIGRATION_FAILED_MESSAGE = "Database migration failed"
 MISMATCHED_AIRFLOW_VERSIONS_MESSAGE = "Integrated apps with mismatched airflow versions"
 MISMATCHED_WORKLOAD_IMAGE_HASHES_MESSAGE = (

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -18,7 +18,10 @@ logger = logging.getLogger(__name__)
 CORE_CHARM_METADATA = yaml.safe_load(
     pathlib.Path("tests/integration/mock-core-charm/charmcraft.yaml").read_text()
 )
-
+CHARMCRAFT_FILE = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text())
+WORKLOAD_IMAGE = image_path = CHARMCRAFT_FILE["resources"]["airflow-coordinator-image"][
+    "upstream-source"
+]
 AIRFLOW_VERSION = "3.1.0"
 WORKLOAD_IMAGE_HASH = "somehash"
 AIRFLOW_COMPONENTS = sorted(
@@ -31,11 +34,17 @@ AIRFLOW_COMPONENTS = sorted(
 )
 
 
-def test_deploy(juju: jubilant.Juju, charm: pathlib.Path, mock_core_charm: pathlib.Path):
+def test_deploy(
+    juju: jubilant.Juju, charm: pathlib.Path, mock_core_charm: pathlib.Path
+):
     """Deploy the charm under test."""
     logger.info("Deploying coordinator + postgresql")
 
-    juju.deploy(charm.resolve(), app="airflow-coordinator-k8s")
+    juju.deploy(
+        charm.resolve(),
+        app="airflow-coordinator-k8s",
+        resources={"airflow-coordinator-image": WORKLOAD_IMAGE},
+    )
 
     # TODO: change postgres to 16/stable once released
     juju.deploy(
@@ -74,9 +83,9 @@ def test_deploy(juju: jubilant.Juju, charm: pathlib.Path, mock_core_charm: pathl
                 "workload_image_hash": WORKLOAD_IMAGE_HASH,
             },
             resources={
-                "workload-container": CORE_CHARM_METADATA["resources"]["workload-container"][
-                    "upstream-source"
-                ],
+                "workload-container": CORE_CHARM_METADATA["resources"][
+                    "workload-container"
+                ]["upstream-source"],
             },
         )
 
@@ -285,7 +294,10 @@ def test_break_and_recreate_postgres_relation(juju: jubilant.Juju):
     )
 
     for component in AIRFLOW_COMPONENTS:
-        assert juju.run(f"airflow-{component}-mock/0", "check-ready").results["ready"] == "False"
+        assert (
+            juju.run(f"airflow-{component}-mock/0", "check-ready").results["ready"]
+            == "False"
+        )
 
     logger.info("Recreate integration between coordinator <-> postgres")
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -98,6 +98,11 @@ def dag_processor_relation(dag_processor_data):
 
 
 @pytest.fixture(scope="function")
+def peer_relation():
+    return ops.testing.PeerRelation(constants.PEER_RELATION_NAME)
+
+
+@pytest.fixture(scope="function")
 def postgres_relation():
     relation = ops.testing.Relation("postgres", remote_app_data=POSTGRES_DATA)
 
@@ -120,6 +125,7 @@ def all_required_relations(
     scheduler_relation,
     triggerer_relation,
     dag_processor_relation,
+    peer_relation,
 ):
     return [
         postgres_relation,
@@ -127,6 +133,7 @@ def all_required_relations(
         scheduler_relation,
         triggerer_relation,
         dag_processor_relation,
+        peer_relation,
     ]
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,6 +7,8 @@ import unittest.mock
 import ops.testing
 import pytest
 
+import command_executor
+import constants
 from charm import AirflowCoordinatorK8SOperatorCharm
 
 logger = logging.getLogger(__name__)
@@ -20,9 +22,7 @@ POSTGRES_DATA = {
 }
 
 
-POSTGRES_SQL_ALCHEMY_STRING = (
-    "postgresql+psycopg2://airflow_user:airflow_password@airflow_host:airflow_port/airflow"
-)
+POSTGRES_SQL_ALCHEMY_STRING = "postgresql+psycopg2://airflow_user:airflow_password@airflow_host:airflow_port/airflow"
 
 
 @pytest.fixture
@@ -35,8 +35,18 @@ def context(airflow_coordinator_k8s_charm):
     return ops.testing.Context(charm_type=airflow_coordinator_k8s_charm)
 
 
+@pytest.fixture(scope="function")
+def workload_container():
+    return ops.testing.Container(
+        constants.WORKLOAD_CONTAINER_NAME,
+        can_connect=True,
+    )
+
+
 def core_component_metadata(
-    component: str, airflow_version: str = "3.1.0", workload_image_hash: str = "somehash"
+    component: str,
+    airflow_version: str = "3.1.0",
+    workload_image_hash: str = "somehash",
 ) -> dict[str, str]:
     return {
         "airflow_version": airflow_version,
@@ -82,7 +92,9 @@ def triggerer_relation(triggerer_data):
 
 @pytest.fixture(scope="function")
 def dag_processor_relation(dag_processor_data):
-    return ops.testing.Relation("airflow-coordinator", remote_app_data=dag_processor_data)
+    return ops.testing.Relation(
+        "airflow-coordinator", remote_app_data=dag_processor_data
+    )
 
 
 @pytest.fixture(scope="function")
@@ -118,9 +130,34 @@ def all_required_relations(
     ]
 
 
+@pytest.fixture
+def mock_run_db_migrate():
+    """Mock the charm's _run_db_migrate method."""
+    with unittest.mock.patch.object(
+        AirflowCoordinatorK8SOperatorCharm,
+        "_run_db_migrate",
+    ) as mock:
+        yield mock
+
+
 @pytest.fixture(scope="function")
-def state(all_required_relations):
+def mock_command_executor():
+    """Mock the command executor to avoid actual container operations."""
+    with unittest.mock.patch.object(
+        command_executor.CommandExecutor, "run_db_migrate"
+    ) as mock_run_db_migrate:
+        mock_run_db_migrate.return_value = command_executor.CommandExecutionResult(
+            success=True, stdout="", stderr="", return_code=0
+        )
+        yield {
+            "run_db_migrate": mock_run_db_migrate,
+        }
+
+
+@pytest.fixture(scope="function")
+def state(all_required_relations, workload_container, mock_command_executor):
     return ops.testing.State(
         leader=True,
         relations=all_required_relations,
+        containers=[workload_container],
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -141,7 +141,8 @@ def test_invalid_core_charm_airflow_version(
     scheduler_relation_index = [
         index
         for index, relation in enumerate(all_required_relations)
-        if relation.remote_app_data.get("component") == "scheduler"
+        if hasattr(relation, "remote_app_data")
+        and relation.remote_app_data.get("component") == "scheduler"
     ][0]
     del all_required_relations[scheduler_relation_index]
     all_required_relations.append(modified_scheduler_relation)
@@ -185,7 +186,8 @@ def test_invalid_core_charm_workload_image_hash(
     scheduler_relation_index = [
         index
         for index, relation in enumerate(all_required_relations)
-        if relation.remote_app_data.get("component") == "scheduler"
+        if hasattr(relation, "remote_app_data")
+        and relation.remote_app_data.get("component") == "scheduler"
     ][0]
     del all_required_relations[scheduler_relation_index]
     all_required_relations.append(modified_scheduler_relation)
@@ -212,9 +214,22 @@ def test_invalid_core_charm_workload_image_hash(
 
 
 def test_db_migration_does_not_run_on_state_true(
-    context, state, all_required_relations, mock_run_db_migrate, workload_container
+    context,
+    all_required_relations,
+    mock_run_db_migrate,
+    workload_container,
+    peer_relation,
 ):
-    """Verify that database migration does not happen when stored state is True."""
+    """Verify that database migration does not happen when peer relation state is True."""
+    # Update peer relation with migration already ran
+    peer_relation_with_state = dataclasses.replace(
+        peer_relation, local_app_data={"db_migration_ran": "true"}
+    )
+    relations = [
+        r for r in all_required_relations if r.endpoint != constants.PEER_RELATION_NAME
+    ]
+    relations.append(peer_relation_with_state)
+
     with unittest.mock.patch(
         "config_generator.AirflowConfigGenerator.config_template",
         new_callable=unittest.mock.PropertyMock(
@@ -223,20 +238,8 @@ def test_db_migration_does_not_run_on_state_true(
     ):
         state_in = ops.testing.State(
             leader=True,
-            containers={
-                workload_container: ops.testing.Container(
-                    name=workload_container,
-                    can_connect=True,
-                )
-            },
-            stored_states={
-                ops.testing.StoredState(
-                    "_stored",
-                    owner_path="AirflowCoordinatorK8SOperatorCharm",
-                    content={"db_migration_ran": True},
-                )
-            },
-            relations=all_required_relations,
+            containers=[workload_container],
+            relations=relations,
         )
 
         context.run(
@@ -248,9 +251,14 @@ def test_db_migration_does_not_run_on_state_true(
 
 
 def test_db_migration_runs_on_state_false(
-    context, state, all_required_relations, mock_run_db_migrate, workload_container
+    context,
+    all_required_relations,
+    mock_run_db_migrate,
+    workload_container,
+    peer_relation,
 ):
-    """Verify that database migration happens when stored state is False."""
+    """Verify that database migration happens when peer relation state is False."""
+    # Peer relation with no migration state (defaults to False)
     with unittest.mock.patch(
         "config_generator.AirflowConfigGenerator.config_template",
         new_callable=unittest.mock.PropertyMock(
@@ -259,19 +267,7 @@ def test_db_migration_runs_on_state_false(
     ):
         state_in = ops.testing.State(
             leader=True,
-            containers={
-                workload_container: ops.testing.Container(
-                    name=workload_container,
-                    can_connect=True,
-                )
-            },
-            stored_states={
-                ops.testing.StoredState(
-                    "_stored",
-                    owner_path="AirflowCoordinatorK8SOperatorCharm",
-                    content={"db_migration_ran": False},
-                )
-            },
+            containers=[workload_container],
             relations=all_required_relations,
         )
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,12 +10,12 @@ import unittest.mock
 import charms.airflow_coordinator_k8s.v0.airflow_coordinator as airflow_coordinator
 import ops
 import ops.testing
-from conftest import POSTGRES_SQL_ALCHEMY_STRING
 
+import command_executor
 import constants
 
 
-def test_non_leader_unit(context, state):
+def test_non_leader_unit(context, state, mock_command_executor):
     state = dataclasses.replace(state, leader=False)
 
     unit_status_before = state.unit_status
@@ -25,7 +25,24 @@ def test_non_leader_unit(context, state):
     assert state_out.unit_status == unit_status_before
 
 
-def test_missing_postgres_relation(context, state, all_required_relations, postgres_relation):
+def test_container_not_ready(
+    context, state, mock_command_executor, workload_container, all_required_relations
+):
+    container_not_ready = dataclasses.replace(workload_container, can_connect=False)
+    state = dataclasses.replace(
+        state, relations=all_required_relations, containers=[container_not_ready]
+    )
+
+    state_out = context.run(context.on.start(), state)
+
+    assert state_out.unit_status == ops.WaitingStatus(
+        constants.WAITING_FOR_CONTAINER_MESSAGE
+    )
+
+
+def test_missing_postgres_relation(
+    context, state, all_required_relations, postgres_relation, mock_command_executor
+):
     all_required_relations.remove(postgres_relation)
     state = dataclasses.replace(state, relations=all_required_relations)
 
@@ -50,7 +67,9 @@ def test_missing_postgres_relation(context, state, all_required_relations, postg
         }
 
 
-def test_missing_postgres_relation_data(context, state, all_required_relations, postgres_relation):
+def test_missing_postgres_relation_data(
+    context, state, all_required_relations, postgres_relation, mock_command_executor
+):
     empty_postgres_relation = dataclasses.replace(postgres_relation, remote_app_data={})
 
     all_required_relations.remove(postgres_relation)
@@ -68,7 +87,12 @@ def test_missing_postgres_relation_data(context, state, all_required_relations, 
 
 
 def test_missing_core_charm_relations(
-    context, state, all_required_relations, scheduler_relation, triggerer_relation
+    context,
+    state,
+    all_required_relations,
+    scheduler_relation,
+    triggerer_relation,
+    mock_command_executor,
 ):
     all_required_relations.remove(scheduler_relation)
     all_required_relations.remove(triggerer_relation)
@@ -102,7 +126,12 @@ def test_missing_core_charm_relations(
 
 
 def test_invalid_core_charm_airflow_version(
-    context, state, all_required_relations, scheduler_data, scheduler_relation
+    context,
+    state,
+    all_required_relations,
+    scheduler_data,
+    scheduler_relation,
+    mock_command_executor,
 ):
     scheduler_data["airflow_version"] = "0.0.0"
     modified_scheduler_relation = dataclasses.replace(
@@ -141,7 +170,12 @@ def test_invalid_core_charm_airflow_version(
 
 
 def test_invalid_core_charm_workload_image_hash(
-    context, state, all_required_relations, scheduler_data, scheduler_relation
+    context,
+    state,
+    all_required_relations,
+    scheduler_data,
+    scheduler_relation,
+    mock_command_executor,
 ):
     scheduler_data["workload_image_hash"] = "invalidhash"
     modified_scheduler_relation = dataclasses.replace(
@@ -177,27 +211,125 @@ def test_invalid_core_charm_workload_image_hash(
         assert relation.local_app_data == {"validation-failures": failures}
 
 
-def test_happy_path(context, state, postgres_relation):
+def test_db_migration_does_not_run_on_state_true(
+    context, state, all_required_relations, mock_run_db_migrate, workload_container
+):
+    """Verify that database migration does not happen when stored state is True."""
     with unittest.mock.patch(
         "config_generator.AirflowConfigGenerator.config_template",
         new_callable=unittest.mock.PropertyMock(
             return_value="mock_config: {{ sql_alchemy_connection_string }}"
         ),
     ):
-        state_out = context.run(context.on.start(), state)
-
-    assert state_out.unit_status == ops.ActiveStatus()
-
-    for relation in state_out.get_relations("airflow-coordinator"):
-        assert (
-            relation.local_app_data["config-template"]
-            == "mock_config: {{ sql_alchemy_connection_string }}"
+        state_in = ops.testing.State(
+            leader=True,
+            containers={
+                workload_container: ops.testing.Container(
+                    name=workload_container,
+                    can_connect=True,
+                )
+            },
+            stored_states={
+                ops.testing.StoredState(
+                    "_stored",
+                    owner_path="AirflowCoordinatorK8SOperatorCharm",
+                    content={"db_migration_ran": True},
+                )
+            },
+            relations=all_required_relations,
         )
 
-        assert state_out.get_secret(
-            id=relation.local_app_data["secret-sensitive-data"]
-        ).latest_content == {
-            "sensitive-data": json.dumps(
-                {"sql_alchemy_connection_string": POSTGRES_SQL_ALCHEMY_STRING}
-            )
-        }
+        context.run(
+            context.on.pebble_ready(workload_container),
+            state_in,
+        )
+
+    mock_run_db_migrate.assert_not_called()
+
+
+def test_db_migration_runs_on_state_false(
+    context, state, all_required_relations, mock_run_db_migrate, workload_container
+):
+    """Verify that database migration happens when stored state is False."""
+    with unittest.mock.patch(
+        "config_generator.AirflowConfigGenerator.config_template",
+        new_callable=unittest.mock.PropertyMock(
+            return_value="mock_config: {{ sql_alchemy_connection_string }}"
+        ),
+    ):
+        state_in = ops.testing.State(
+            leader=True,
+            containers={
+                workload_container: ops.testing.Container(
+                    name=workload_container,
+                    can_connect=True,
+                )
+            },
+            stored_states={
+                ops.testing.StoredState(
+                    "_stored",
+                    owner_path="AirflowCoordinatorK8SOperatorCharm",
+                    content={"db_migration_ran": False},
+                )
+            },
+            relations=all_required_relations,
+        )
+
+        context.run(
+            context.on.pebble_ready(workload_container),
+            state_in,
+        )
+
+    mock_run_db_migrate.assert_called_once()
+
+
+def test_db_migration_failure(
+    context, state, mock_command_executor, workload_container
+):
+    mock_command_executor["run_db_migrate"].return_value = (
+        command_executor.CommandExecutionResult(
+            success=False, stdout="", stderr="Migration failed", return_code=1
+        )
+    )
+
+    with unittest.mock.patch(
+        "config_generator.AirflowConfigGenerator.config_template",
+        new_callable=unittest.mock.PropertyMock(
+            return_value="mock_config: {{ sql_alchemy_connection_string }}"
+        ),
+    ):
+        state_out = context.run(context.on.pebble_ready(workload_container), state)
+
+    assert state_out.unit_status == ops.BlockedStatus(
+        constants.DB_MIGRATION_FAILED_MESSAGE
+    )
+
+    # Verify that config was not distributed to core charms
+    for relation in state_out.get_relations("airflow-coordinator"):
+        assert "config-template" not in relation.local_app_data
+
+
+class TestPebbleLayer:
+    def test_pebble_layer_structure(
+        self, context, state, mock_command_executor, workload_container
+    ):
+        with context(context.on.start(), state) as manager:
+            charm = manager.charm
+            layer = charm._airflow_coordinator_layer
+
+        assert "services" in layer
+        assert "airflow" in layer["services"]
+        assert layer["services"]["airflow"]["override"] == "merge"
+        assert layer["services"]["airflow"]["startup"] == "disabled"
+
+    def test_pebble_layer_disables_health_check(
+        self, context, state, mock_command_executor, workload_container
+    ):
+        with context(context.on.start(), state) as manager:
+            charm = manager.charm
+            layer = charm._airflow_coordinator_layer
+
+        assert "checks" in layer
+        assert "airflow-running" in layer["checks"]
+        assert layer["checks"]["airflow-running"]["override"] == "replace"
+        assert layer["checks"]["airflow-running"]["exec"]["command"] == "/bin/true"

--- a/tests/unit/test_command_executor.py
+++ b/tests/unit/test_command_executor.py
@@ -1,0 +1,74 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Tests for the command_executor module."""
+
+import unittest.mock
+
+import ops.pebble
+import pytest
+
+import command_executor
+
+
+@pytest.fixture
+def mock_container():
+    """Create a mock container."""
+    container = unittest.mock.MagicMock(spec=ops.Container)
+    container.can_connect.return_value = True
+    return container
+
+
+@pytest.fixture
+def executor(mock_container):
+    """Create a CommandExecutor instance with a mock container."""
+    return command_executor.CommandExecutor(mock_container)
+
+
+class TestCommandExecutor:
+    def test_run_db_migrate_success(self, executor, mock_container):
+        mock_process = unittest.mock.MagicMock()
+        mock_process.wait_output.return_value = ("Migration successful", "")
+        mock_container.exec.return_value = mock_process
+
+        result = executor.run_db_migrate()
+
+        assert result.success is True
+        assert result.stdout == "Migration successful"
+        assert result.stderr == ""
+        assert result.return_code == 0
+
+        mock_container.exec.assert_called_once_with(
+            ["airflow", "db", "migrate"],
+            environment={"AIRFLOW_HOME": "/", "AIRFLOW__CORE__DAGS_FOLDER": "/dags"},
+        )
+
+    def test_run_db_migrate_not_connected(self, executor, mock_container):
+        mock_container.can_connect.return_value = False
+
+        with pytest.raises(command_executor.CommandExecutionError) as exc_info:
+            executor.run_db_migrate()
+
+        assert "Cannot connect to workload container" in str(exc_info.value)
+
+    def test_run_db_migrate_exec_error(self, executor, mock_container):
+        mock_container.exec.side_effect = ops.pebble.ExecError(
+            command=["airflow", "db", "migrate"],
+            exit_code=1,
+            stdout="",
+            stderr="Migration failed",
+        )
+
+        result = executor.run_db_migrate()
+
+        assert result.success is False
+        assert result.return_code == 1
+        assert result.stderr == "Migration failed"
+
+    def test_run_db_migrate_unexpected_error(self, executor, mock_container):
+        mock_container.exec.side_effect = Exception("Unexpected error")
+
+        with pytest.raises(command_executor.CommandExecutionError) as exc_info:
+            executor.run_db_migrate()
+
+        assert "Failed to execute 'airflow db migrate'" in str(exc_info.value)


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

To ensure all Airflow services can be started, the airflow db migrate
command must run at least once. According to the docs:

Usually, you need to run airflow db migrate in order to create the database schema
if it does not exist or migrate to the latest version if it does.

This commit enables the coordinator charm to do it as it has access to
the Airflow config and the database credentials. It can also control
when the command is run and under which conditions.

For this feature to work, the coordinator charm now has a workload
container that uses the ubuntu/airflow image.

Fixes https://github.com/canonical/airflow-coordinator-k8s-operator/issues/11

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->


1. Clone the core charms repo and update the library with the version from this PR
2. Build the core and the coordinator charms
3. Deploy postgresql-k8s 14/stable and integrate with coordinator
4. Integrate coordinator with core charms
5. Check debug logs, we are looking for:

```
unit-coor-0: 14:18:22 INFO unit.coor/0.juju-log airflow-coordinator:134: 'airflow db migrate' completed successfully
```

6. The services must be up and running, for example

```
$ kubectl logs -nairflow-demo api-server-0 -c airflow-api-server
2026-01-26T20:18:25.743Z [pebble] GET /v1/notices?after=2026-01-26T20%3A18%3A25.586989401Z&timeout=30s 149.610424ms 200
2026-01-26T20:18:26.051Z [airflow]   ____________       _____________
2026-01-26T20:18:26.051Z [airflow]  ____    |__( )_________  __/__  /________      __
2026-01-26T20:18:26.051Z [airflow] ____  /| |_  /__  ___/_  /_ __  /_  __ \_ | /| / /
2026-01-26T20:18:26.051Z [airflow] ___  ___ |  / _  /   _  __/ _  / / /_/ /_ |/ |/ /
2026-01-26T20:18:26.051Z [airflow]  _/_/  |_/_/  /_/    /_/    /_/  \____/____/|__/
2026-01-26T20:18:26.051Z [airflow] 2026-01-26T20:18:26.051417Z [warning  ] `api_auth/jwt_secret` was empty, using a generated one for now. Please set this in your config [airflow.api_fastapi.auth.tokens] loc=tokens.py:529
2026-01-26T20:18:26.051Z [airflow] 2026-01-26T20:18:26.051675Z [info     ] Running the uvicorn with:
2026-01-26T20:18:26.051Z [airflow] Apps: all
2026-01-26T20:18:26.051Z [airflow] Workers: 1
2026-01-26T20:18:26.051Z [airflow] Host: 0.0.0.0:8080
2026-01-26T20:18:26.051Z [airflow] Timeout: 120
2026-01-26T20:18:26.051Z [airflow] Logfiles: -
2026-01-26T20:18:26.051Z [airflow] ================================================================= [airflow.cli.commands.api_server_command] loc=api_server_command.py:54
2026-01-26T20:18:26.080Z [airflow] /lib/python3.12/site-packages/airflow/api_fastapi/execution_api/routes/__init__.py:23 DeprecationWarning: 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead.
2026-01-26T20:18:26.615Z [airflow] /lib/python3.12/site-packages/airflow/api_fastapi/core_api/routes/public/__init__.py:37 DeprecationWarning: 'HTTP_422_UNPROCESSABLE_ENTITY' is deprecated. Use 'HTTP_422_UNPROCESSABLE_CONTENT' instead.
```

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [x] Integration tests added or updated
- [ ] Documentation updated
