### PR TITLE
[WF-261] Add CI workflow job to publish charm libs upon merge to default branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,8 +12,8 @@ jobs:
     name: Release tests
     uses: ./.github/workflows/tests.yaml
 
-  build:
-    name: 'Build charm | amd64'
+  publish:
+    name: 'Publish charm to edge | amd64'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -27,4 +27,19 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           channel: 3.1/edge
           tag-prefix: airflow-coordinator
+          charmcraft-channel: 3.x/stable
+
+  publish-libs:
+    name: 'Publish charm libs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Upload charm lib
+        uses: canonical/charming-actions/release-libraries@2.6.2
+        with:
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           charmcraft-channel: 3.x/stable


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Upon merge, publish charm libs to charmhub

Uses the `release-libraries` charming action. Independent to the job to publish charm to edge 

<!-- Reference  the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
