### PR TITLE
Make tests a prereq for publish and publish-libs CI jobs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,6 +15,8 @@ jobs:
   publish:
     name: 'Publish charm to edge | amd64'
     runs-on: ubuntu-latest
+    needs:
+      - tests
     timeout-minutes: 60
     steps:
       - name: Checkout
@@ -32,6 +34,8 @@ jobs:
   publish-libs:
     name: 'Publish charm libs'
     runs-on: ubuntu-latest
+    needs:
+      - tests
     timeout-minutes: 10
     steps:
       - name: Checkout


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
We run tests, publish charm and publish charm lib jobs when a PR is merged to the default branch.

However, we should only run the publish and publish charm lib jobs if the tests pass.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
