### PR TITLE
Use airflow-api-server charm lib to accept host+port to compose base_url

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -38,10 +38,6 @@ parts:
     stage:
       - LICENSE
 
-provides:
-  airflow-coordinator:
-    interface: airflow_coordinator
-
 containers:
   airflow-coordinator:
     resource: airflow-coordinator-image
@@ -52,9 +48,17 @@ resources:
     description: Airflow workload container for running commands
     upstream-source: ubuntu/airflow:3.1-24.04_edge
 
+provides:
+  airflow-coordinator:
+    interface: airflow_coordinator
+
 requires:
   postgres:
     interface: postgresql_client
+    limit: 1
+  airflow-api-server:
+    interface: airflow_api_server
+    limit: 1
 
 peers:
   coordinator-peers:

--- a/lib/charms/airflow_api_server_k8s/v0/airflow_api_server.py
+++ b/lib/charms/airflow_api_server_k8s/v0/airflow_api_server.py
@@ -1,0 +1,142 @@
+"""Library to manage the relation provided by Airflow API Server charm.
+
+This library contains the Requires and Provides classes for handing the relation
+between the Airflow API Server charm and the Airflow Coordinator charm. This
+relation interface provides a way for the API server charm to convey information
+that will affect the global `airflow.cfg` file distributed by Airflow Coordinator.
+
+### Requirer Charm
+
+The following presents an example usage of the AirflowAPIServerRequires class:
+
+```python
+import charms.airflow_api_server_k8s.v0.airflow_api_server as airflow_api_server
+
+class AirflowCoordinatorCharm(ops.CharmBase):
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+        self.requirer = airflow_api_server.AirflowAPIServerRequires(
+            self,
+            "airflow-api-server", # relation endpoint
+            callback=self.reconcile,
+        )
+
+    def reconcile(self, event) -> None:
+        # Access the API server host and port
+        self.requirer.api_server_host
+        self.requirer.api_server_port
+```
+
+### Provider Charm
+
+The following presents an example usage of the AirflowAPIServerProvides class:
+
+```python
+import charms.airflow_api_server_k8s.v0.airflow_api_server as airflow_api_server
+
+class AirflowAPIServerCharm(ops.CharmBase):
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+        self.requirer = airflow_api_server.AirflowAPIServerProviders(
+            self,
+            "airflow-api-server", # relation endpoint
+            "airflow-api-server-k8s-endpoints.airflow-model.svc.cluster.local", # host
+            "8080", # port
+        )
+```
+
+"""
+
+import logging
+import typing
+
+import ops
+
+# The unique Charmhub library identifier, never change it
+LIBID = "a0959775f225419d86d202cd754066cf"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+HOST_KEY = "host"
+PORT_KEY = "port"
+
+logger = logging.getLogger(__name__)
+
+
+class AirflowAPIServerProvides(ops.Object):
+    """A provider handler encapsulating the airflow api server relation."""
+
+    def __init__(
+        self,
+        charm: ops.CharmBase,
+        relation_name: str,
+        host: str,
+        port: str,
+    ):
+        super().__init__(charm, relation_name)
+
+        self._charm = charm
+        self._relation = charm.model.get_relation(relation_name)
+
+        self._set_api_server_host_info(host, port)
+
+    def _set_api_server_host_info(self, host: str, port: str):
+        """Write the API server host and port to the relation."""
+        if not self._relation or not self._charm.unit.is_leader():
+            return
+
+        if not host:
+            logger.error("Invalid host to set in airflow_api_server relation")
+            return
+
+        if not port:
+            logger.error("Invalid port to set in airflow_api_server relation")
+            return
+
+        self._relation.data[self._charm.app][HOST_KEY] = host
+        self._relation.data[self._charm.app][PORT_KEY] = port
+
+
+class AirflowAPIServerRequires(ops.Object):
+    """A requirer handler encapsulating the airflow api server relation."""
+
+    def __init__(
+        self,
+        charm: ops.CharmBase,
+        relation_name: str,
+        callback: typing.Callable,
+    ):
+        super().__init__(charm, relation_name)
+
+        self._charm = charm
+        self._relation = charm.model.get_relation(relation_name)
+
+        for event in [
+            charm.on[relation_name].relation_changed,
+            charm.on[relation_name].relation_broken,
+        ]:
+            self.framework.observe(event, callback)
+
+    @property
+    def api_server_host(self) -> typing.Optional[str]:
+        """Return API server (host, port) tuple."""
+        if not self._relation or not self._relation.app:
+            return None
+
+        return self._relation.data[self._relation.app].get(HOST_KEY)
+
+    @property
+    def api_server_port(self) -> typing.Optional[str]:
+        """Return API server (host, port) tuple."""
+        if not self._relation or not self._relation.app:
+            return None
+
+        return self._relation.data[self._relation.app].get(PORT_KEY)
+

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -810,7 +810,8 @@ class AirflowCoordinatorRequires(ops.Object):
             return False
 
         return all(
-            condition for condition in [
+            condition
+            for condition in [
                 self._ready,
                 self._requirer_handler.provider_content,
                 self._requirer_handler.provider_content.config_template,

--- a/src/charm.py
+++ b/src/charm.py
@@ -6,6 +6,7 @@
 
 import logging
 
+import charms.airflow_api_server_k8s.v0.airflow_api_server as airflow_api_server
 import charms.airflow_coordinator_k8s.v0.airflow_coordinator as airflow_coordinator
 import charms.data_platform_libs.v0.data_interfaces as data_interfaces_v0
 import ops
@@ -52,6 +53,11 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
             constants.AIRFLOW_COORDINATOR_RELATION_NAME,
             callback=self._reconcile,
             dependencies_check_callable=self._required_dependencies_exist,
+        )
+        self._api_server_requires = airflow_api_server.AirflowAPIServerRequires(
+            self,
+            constants.AIRFLOW_API_SERVER_ENDPOINT_NAME,
+            callback=self._reconcile,
         )
 
         for event in [
@@ -139,6 +145,7 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
         return all(
             [
                 self.model.get_relation(constants.POSTGRES_RELATION_NAME),
+                self.model.get_relation(constants.AIRFLOW_API_SERVER_ENDPOINT_NAME),
             ]
         )
 
@@ -163,6 +170,20 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
         if not self._all_database_connection_details_present:
             raise ExceptionWithStatusError(
                 constants.WAITING_FOR_DATABASE_CONNECTION_MESSAGE, ops.WaitingStatus
+            )
+
+        if not self.model.get_relation(constants.AIRFLOW_API_SERVER_ENDPOINT_NAME):
+            self._config_provider.set_validation_errors()
+            raise ExceptionWithStatusError(
+                constants.WAITING_FOR_API_SERVER_RELATION_MESSAGE, ops.BlockedStatus
+            )
+
+        if (
+            not self._api_server_requires.api_server_host
+            or not self._api_server_requires.api_server_port
+        ):
+            raise ExceptionWithStatusError(
+                constants.WAITING_FOR_API_SERVER_HOST_PORT_MESSAGE, ops.WaitingStatus
             )
 
         missing_core_components = self._config_provider.missing_core_components

--- a/src/command_executor.py
+++ b/src/command_executor.py
@@ -14,9 +14,7 @@ logger = logging.getLogger(__name__)
 class CommandExecutionError(Exception):
     """Exception raised when command execution fails."""
 
-    def __init__(
-        self, message: str, return_code: int | None = None, stderr: str | None = None
-    ):
+    def __init__(self, message: str, return_code: int | None = None, stderr: str | None = None):
         super().__init__(message)
         self.message = message
         self.return_code = return_code
@@ -75,9 +73,7 @@ class CommandExecutor:
                 return_code=0,
             )
         except ops.pebble.ExecError as e:
-            logger.error(
-                f"'airflow db migrate' failed with exit code {e.exit_code}: {e.stderr}"
-            )
+            logger.error(f"'airflow db migrate' failed with exit code {e.exit_code}: {e.stderr}")
             return CommandExecutionResult(
                 success=False,
                 stdout=e.stdout or "",
@@ -86,6 +82,4 @@ class CommandExecutor:
             )
         except Exception as e:
             logger.error(f"Unexpected error executing 'airflow db migrate': {e}")
-            raise CommandExecutionError(
-                f"Failed to execute 'airflow db migrate': {e}"
-            ) from e
+            raise CommandExecutionError(f"Failed to execute 'airflow db migrate': {e}") from e

--- a/src/config_generator.py
+++ b/src/config_generator.py
@@ -5,6 +5,7 @@
 
 import logging
 
+import jinja2
 import ops
 
 logger = logging.getLogger(__name__)
@@ -22,7 +23,16 @@ class AirflowConfigGenerator:
         with open("src/templates/airflow_config.j2") as config_template_file:
             config_template = config_template_file.read()
 
-        return config_template
+        return (
+            jinja2.Environment(loader=jinja2.BaseLoader(), undefined=jinja2.DebugUndefined)
+            .from_string(config_template)
+            .render(
+                {
+                    "api_server_base_url": f"http://{self._charm._api_server_requires.api_server_host}:{self._charm._api_server_requires.api_server_port}",
+                    "api_server_port": self._charm._api_server_requires.api_server_port,
+                }
+            )
+        )
 
     @property
     def _sql_alchemy_connection_string(self) -> str:

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,6 +4,7 @@
 """Constants to be used in the Airflow Coordiantor charm."""
 
 AIRFLOW_COORDINATOR_RELATION_NAME = "airflow-coordinator"
+AIRFLOW_API_SERVER_ENDPOINT_NAME = "airflow-api-server"
 
 PEER_RELATION_NAME = "coordinator-peers"
 
@@ -14,19 +15,13 @@ WORKLOAD_CONTAINER_NAME = "airflow-coordinator"
 AIRFLOW_CONFIG_PATH = "/airflow.cfg"
 
 MISSING_POSTGRES_INTEGRATION_MESSAGE = "Missing integration with postgres"
-WAITING_FOR_DATABASE_TO_BE_CREATED_MESSAGE = (
-    "Waiting for airflow database to be created"
-)
-WAITING_FOR_DATABASE_CONNECTION_MESSAGE = (
-    "Waiting for database connection info from postgres"
-)
+WAITING_FOR_DATABASE_TO_BE_CREATED_MESSAGE = "Waiting for airflow database to be created"
+WAITING_FOR_DATABASE_CONNECTION_MESSAGE = "Waiting for database connection info from postgres"
 WAITING_FOR_CONTAINER_MESSAGE = "Waiting for workload container"
 WAITING_FOR_PEER_RELATION_MESSAGE = "Waiting for peer relation"
 DB_MIGRATION_FAILED_MESSAGE = "Database migration failed"
+WAITING_FOR_API_SERVER_RELATION_MESSAGE = "Waiting for airflow_api_server interface integration"
+WAITING_FOR_API_SERVER_HOST_PORT_MESSAGE = "Waiting for host+port information from api server"
 MISMATCHED_AIRFLOW_VERSIONS_MESSAGE = "Integrated apps with mismatched airflow versions"
-MISMATCHED_WORKLOAD_IMAGE_HASHES_MESSAGE = (
-    "Integrated apps with mismatched workload image hashes"
-)
-MISSING_INTEGRATIONS_MESSAGE_TEMPLATE = (
-    "Missing integrations with: {missing_core_components}"
-)
+MISMATCHED_WORKLOAD_IMAGE_HASHES_MESSAGE = "Integrated apps with mismatched workload image hashes"
+MISSING_INTEGRATIONS_MESSAGE_TEMPLATE = "Missing integrations with: {missing_core_components}"

--- a/src/templates/airflow_config.j2
+++ b/src/templates/airflow_config.j2
@@ -7,7 +7,8 @@ load_examples = False
 sql_alchemy_conn = {{ sql_alchemy_connection_string }}
 
 [api]
-port = 8080
+base_url = {{ api_server_base_url }}
+port = {{ api_server_port }}
 
 [logging]
 base_log_folder = logs

--- a/tests/integration/mock-core-charm/charmcraft.yaml
+++ b/tests/integration/mock-core-charm/charmcraft.yaml
@@ -43,6 +43,11 @@ requires:
     interface: airflow_coordinator
     limit: 1
 
+provides:
+  airflow-api-server:
+    interface: airflow_api_server
+    limit: 1
+
 config:
   options:
     component:

--- a/tests/integration/mock-core-charm/src/charm.py
+++ b/tests/integration/mock-core-charm/src/charm.py
@@ -12,6 +12,7 @@ from charms.airflow_coordinator_k8s.v0 import airflow_coordinator
 logger = logging.getLogger(__name__)
 
 AIRFLOW_COORDINATOR_RELATION_NAME = "airflow-coordinator"
+AIRFLOW_API_SERVER_RELATION_NAME = "airflow-api-server"
 CONTAINER_NAME = "workload"
 AIRFLOW_CONFIG_PATH = "/airflow.cfg"
 K8S_EXECUTOR_POD_SPEC_PATH = "/k8s_executor_pod_spec"
@@ -44,8 +45,16 @@ class MockCoreCharmCharm(ops.CharmBase):
             self.on[AIRFLOW_COORDINATOR_RELATION_NAME].relation_joined,
             self.on[AIRFLOW_COORDINATOR_RELATION_NAME].relation_changed,
             self.on[AIRFLOW_COORDINATOR_RELATION_NAME].relation_broken,
+            self.on[AIRFLOW_API_SERVER_RELATION_NAME].relation_joined,
+            self.on[AIRFLOW_API_SERVER_RELATION_NAME].relation_changed,
+            self.on[AIRFLOW_API_SERVER_RELATION_NAME].relation_broken,
         ]:
             self.framework.observe(event, self.log_event_and_set_status)
+
+        self.framework.observe(
+            self.on[AIRFLOW_API_SERVER_RELATION_NAME].relation_joined,
+            self._populate_api_server_relation,
+        )
 
         self.framework.observe(self.on.check_ready_action, self._check_ready)
         self.framework.observe(self.on.get_airflow_config_action, self._get_airflow_config)
@@ -95,6 +104,13 @@ class MockCoreCharmCharm(ops.CharmBase):
             return
 
         self.unit.status = ops.ActiveStatus()
+
+    def _populate_api_server_relation(self, event: ops.RelationJoinedEvent) -> None:
+        """Populate api-server relation with host+port data."""
+        event.relation.data[self.app]["host"] = (
+            f"{self.app.name}-endpoints.{self.model.name}.svc.cluster.local"
+        )
+        event.relation.data[self.app]["port"] = "8080"
 
     def _check_ready(self, event: ops.ActionEvent) -> None:
         """Exposes whether relation indicates that the Airflow config can be written."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -66,10 +66,6 @@ def test_deploy(juju: jubilant.Juju, charm: pathlib.Path, mock_core_charm: pathl
     juju.wait(
         lambda status: (
             jubilant.all_blocked(status, "airflow-coordinator-k8s")
-            and status.apps["airflow-coordinator-k8s"].app_status.message
-            == constants.MISSING_INTEGRATIONS_MESSAGE_TEMPLATE.format(
-                missing_core_components=", ".join(AIRFLOW_COMPONENTS)
-            )
         )
     )
 
@@ -150,7 +146,7 @@ def test_relate_and_config_validation(juju: jubilant.Juju):
 
     assert (
         f"base_url = http://airflow-api-server-mock-endpoints.{juju.model}.svc.cluster.local:8080"
-        in airflow_configs[0]
+        in next(iter(airflow_configs))
     )
     assert (
         "postgresql+psycopg2://"
@@ -170,7 +166,7 @@ def test_remove_and_recreate_integrations(juju: jubilant.Juju):
     logger.info("Breaking integrations between coordinator <-> mocked core charms")
 
     for component in AIRFLOW_COMPONENTS:
-        juju.remove_relation("airflow-coordinator-k8s", f"airflow-{component}-mock")
+        juju.remove_relation("airflow-coordinator-k8s:airflow-coordinator", f"airflow-{component}-mock:airflow-coordinator")
 
     juju.wait(
         lambda status: (
@@ -192,7 +188,7 @@ def test_remove_and_recreate_integrations(juju: jubilant.Juju):
         )
 
     for component in AIRFLOW_COMPONENTS:
-        juju.integrate("airflow-coordinator-k8s", f"airflow-{component}-mock")
+        juju.integrate("airflow-coordinator-k8s:airflow-coordinator", f"airflow-{component}-mock:airflow-coordinator")
 
     juju.wait(jubilant.all_active)
 
@@ -243,7 +239,7 @@ def test_remove_and_recreate_limited_integrations(juju: jubilant.Juju):
     unrelated_components = ["api-server", "scheduler"]
 
     for component in unrelated_components:
-        juju.remove_relation("airflow-coordinator-k8s", f"airflow-{component}-mock")
+        juju.remove_relation("airflow-coordinator-k8s:airflow-coordinator", f"airflow-{component}-mock:airflow-coordinator")
 
     juju.wait(
         lambda status: (
@@ -265,7 +261,7 @@ def test_remove_and_recreate_limited_integrations(juju: jubilant.Juju):
         )
 
     for component in unrelated_components:
-        juju.integrate("airflow-coordinator-k8s", f"airflow-{component}-mock")
+        juju.integrate("airflow-coordinator-k8s:airflow-coordinator", f"airflow-{component}-mock:airflow-coordinator")
 
     juju.wait(jubilant.all_active)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -63,11 +63,7 @@ def test_deploy(juju: jubilant.Juju, charm: pathlib.Path, mock_core_charm: pathl
 
     juju.integrate("airflow-coordinator-k8s", "postgresql-k8s")
 
-    juju.wait(
-        lambda status: (
-            jubilant.all_blocked(status, "airflow-coordinator-k8s")
-        )
-    )
+    juju.wait(lambda status: jubilant.all_blocked(status, "airflow-coordinator-k8s"))
 
     logger.info("Deploying mocked core charms")
 
@@ -166,7 +162,10 @@ def test_remove_and_recreate_integrations(juju: jubilant.Juju):
     logger.info("Breaking integrations between coordinator <-> mocked core charms")
 
     for component in AIRFLOW_COMPONENTS:
-        juju.remove_relation("airflow-coordinator-k8s:airflow-coordinator", f"airflow-{component}-mock:airflow-coordinator")
+        juju.remove_relation(
+            "airflow-coordinator-k8s:airflow-coordinator",
+            f"airflow-{component}-mock:airflow-coordinator",
+        )
 
     juju.wait(
         lambda status: (
@@ -188,7 +187,10 @@ def test_remove_and_recreate_integrations(juju: jubilant.Juju):
         )
 
     for component in AIRFLOW_COMPONENTS:
-        juju.integrate("airflow-coordinator-k8s:airflow-coordinator", f"airflow-{component}-mock:airflow-coordinator")
+        juju.integrate(
+            "airflow-coordinator-k8s:airflow-coordinator",
+            f"airflow-{component}-mock:airflow-coordinator",
+        )
 
     juju.wait(jubilant.all_active)
 
@@ -239,7 +241,10 @@ def test_remove_and_recreate_limited_integrations(juju: jubilant.Juju):
     unrelated_components = ["api-server", "scheduler"]
 
     for component in unrelated_components:
-        juju.remove_relation("airflow-coordinator-k8s:airflow-coordinator", f"airflow-{component}-mock:airflow-coordinator")
+        juju.remove_relation(
+            "airflow-coordinator-k8s:airflow-coordinator",
+            f"airflow-{component}-mock:airflow-coordinator",
+        )
 
     juju.wait(
         lambda status: (
@@ -261,7 +266,10 @@ def test_remove_and_recreate_limited_integrations(juju: jubilant.Juju):
         )
 
     for component in unrelated_components:
-        juju.integrate("airflow-coordinator-k8s:airflow-coordinator", f"airflow-{component}-mock:airflow-coordinator")
+        juju.integrate(
+            "airflow-coordinator-k8s:airflow-coordinator",
+            f"airflow-{component}-mock:airflow-coordinator",
+        )
 
     juju.wait(jubilant.all_active)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -34,9 +34,7 @@ AIRFLOW_COMPONENTS = sorted(
 )
 
 
-def test_deploy(
-    juju: jubilant.Juju, charm: pathlib.Path, mock_core_charm: pathlib.Path
-):
+def test_deploy(juju: jubilant.Juju, charm: pathlib.Path, mock_core_charm: pathlib.Path):
     """Deploy the charm under test."""
     logger.info("Deploying coordinator + postgresql")
 
@@ -54,9 +52,11 @@ def test_deploy(
     )
 
     juju.wait(
-        lambda status: jubilant.all_blocked(status, "airflow-coordinator-k8s")
-        and status.apps["airflow-coordinator-k8s"].app_status.message
-        == constants.MISSING_POSTGRES_INTEGRATION_MESSAGE
+        lambda status: (
+            jubilant.all_blocked(status, "airflow-coordinator-k8s")
+            and status.apps["airflow-coordinator-k8s"].app_status.message
+            == constants.MISSING_POSTGRES_INTEGRATION_MESSAGE
+        )
     )
 
     logger.info("Integrating coordinator <-> postgres")
@@ -64,10 +64,12 @@ def test_deploy(
     juju.integrate("airflow-coordinator-k8s", "postgresql-k8s")
 
     juju.wait(
-        lambda status: jubilant.all_blocked(status, "airflow-coordinator-k8s")
-        and status.apps["airflow-coordinator-k8s"].app_status.message
-        == constants.MISSING_INTEGRATIONS_MESSAGE_TEMPLATE.format(
-            missing_core_components=", ".join(AIRFLOW_COMPONENTS)
+        lambda status: (
+            jubilant.all_blocked(status, "airflow-coordinator-k8s")
+            and status.apps["airflow-coordinator-k8s"].app_status.message
+            == constants.MISSING_INTEGRATIONS_MESSAGE_TEMPLATE.format(
+                missing_core_components=", ".join(AIRFLOW_COMPONENTS)
+            )
         )
     )
 
@@ -83,9 +85,9 @@ def test_deploy(
                 "workload_image_hash": WORKLOAD_IMAGE_HASH,
             },
             resources={
-                "workload-container": CORE_CHARM_METADATA["resources"][
-                    "workload-container"
-                ]["upstream-source"],
+                "workload-container": CORE_CHARM_METADATA["resources"]["workload-container"][
+                    "upstream-source"
+                ],
             },
         )
 
@@ -156,10 +158,12 @@ def test_remove_and_recreate_integrations(juju: jubilant.Juju):
         juju.remove_relation("airflow-coordinator-k8s", f"airflow-{component}-mock")
 
     juju.wait(
-        lambda status: jubilant.all_blocked(status, "airflow-coordinator-k8s")
-        and status.apps["airflow-coordinator-k8s"].app_status.message
-        == constants.MISSING_INTEGRATIONS_MESSAGE_TEMPLATE.format(
-            missing_core_components=", ".join(AIRFLOW_COMPONENTS)
+        lambda status: (
+            jubilant.all_blocked(status, "airflow-coordinator-k8s")
+            and status.apps["airflow-coordinator-k8s"].app_status.message
+            == constants.MISSING_INTEGRATIONS_MESSAGE_TEMPLATE.format(
+                missing_core_components=", ".join(AIRFLOW_COMPONENTS)
+            )
         )
     )
 
@@ -227,10 +231,12 @@ def test_remove_and_recreate_limited_integrations(juju: jubilant.Juju):
         juju.remove_relation("airflow-coordinator-k8s", f"airflow-{component}-mock")
 
     juju.wait(
-        lambda status: jubilant.all_blocked(status, "airflow-coordinator-k8s")
-        and status.apps["airflow-coordinator-k8s"].app_status.message
-        == constants.MISSING_INTEGRATIONS_MESSAGE_TEMPLATE.format(
-            missing_core_components=", ".join(unrelated_components)
+        lambda status: (
+            jubilant.all_blocked(status, "airflow-coordinator-k8s")
+            and status.apps["airflow-coordinator-k8s"].app_status.message
+            == constants.MISSING_INTEGRATIONS_MESSAGE_TEMPLATE.format(
+                missing_core_components=", ".join(unrelated_components)
+            )
         )
     )
 
@@ -288,16 +294,15 @@ def test_break_and_recreate_postgres_relation(juju: jubilant.Juju):
     juju.remove_relation("airflow-coordinator-k8s", "postgresql-k8s")
 
     juju.wait(
-        lambda status: jubilant.all_blocked(status, "airflow-coordinator-k8s")
-        and status.apps["airflow-coordinator-k8s"].app_status.message
-        == constants.MISSING_POSTGRES_INTEGRATION_MESSAGE
+        lambda status: (
+            jubilant.all_blocked(status, "airflow-coordinator-k8s")
+            and status.apps["airflow-coordinator-k8s"].app_status.message
+            == constants.MISSING_POSTGRES_INTEGRATION_MESSAGE
+        )
     )
 
     for component in AIRFLOW_COMPONENTS:
-        assert (
-            juju.run(f"airflow-{component}-mock/0", "check-ready").results["ready"]
-            == "False"
-        )
+        assert juju.run(f"airflow-{component}-mock/0", "check-ready").results["ready"] == "False"
 
     logger.info("Recreate integration between coordinator <-> postgres")
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -103,10 +103,21 @@ def test_deploy(juju: jubilant.Juju, charm: pathlib.Path, mock_core_charm: pathl
 
 def test_relate_and_config_validation(juju: jubilant.Juju):
     """Relate all the components and confirm proper transfer of config and sensitive data."""
+    logger.info(
+        "Integrating coordinator:airflow-api-server <-> mocked api-server:airflow-api-server"
+    )
+
+    juju.integrate(
+        "airflow-coordinator-k8s:airflow-api-server", "airflow-api-server-mock:airflow-api-server"
+    )
+
     logger.info("Integrating coordinator <-> mocked core charms")
 
     for component in AIRFLOW_COMPONENTS:
-        juju.integrate("airflow-coordinator-k8s", f"airflow-{component}-mock")
+        juju.integrate(
+            "airflow-coordinator-k8s:airflow-coordinator",
+            f"airflow-{component}-mock:airflow-coordinator",
+        )
 
     juju.wait(jubilant.all_active)
 
@@ -137,6 +148,10 @@ def test_relate_and_config_validation(juju: jubilant.Juju):
     assert len(airflow_configs) == 1
     assert len(all_sensitive_data) == 1
 
+    assert (
+        f"base_url = http://airflow-api-server-mock-endpoints.{juju.model}.svc.cluster.local:8080"
+        in airflow_configs[0]
+    )
     assert (
         "postgresql+psycopg2://"
         in json.loads(all_sensitive_data[0])["sql_alchemy_connection_string"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -22,7 +22,9 @@ POSTGRES_DATA = {
 }
 
 
-POSTGRES_SQL_ALCHEMY_STRING = "postgresql+psycopg2://airflow_user:airflow_password@airflow_host:airflow_port/airflow"
+POSTGRES_SQL_ALCHEMY_STRING = (
+    "postgresql+psycopg2://airflow_user:airflow_password@airflow_host:airflow_port/airflow"
+)
 
 
 @pytest.fixture
@@ -92,9 +94,7 @@ def triggerer_relation(triggerer_data):
 
 @pytest.fixture(scope="function")
 def dag_processor_relation(dag_processor_data):
-    return ops.testing.Relation(
-        "airflow-coordinator", remote_app_data=dag_processor_data
-    )
+    return ops.testing.Relation("airflow-coordinator", remote_app_data=dag_processor_data)
 
 
 @pytest.fixture(scope="function")
@@ -119,6 +119,17 @@ def postgres_relation():
 
 
 @pytest.fixture(scope="function")
+def airflow_api_server_requires_relation():
+    return ops.testing.Relation(
+        "airflow-api-server",
+        remote_app_data={
+            "host": "test-host",
+            "port": "test-port",
+        },
+    )
+
+
+@pytest.fixture(scope="function")
 def all_required_relations(
     postgres_relation,
     api_server_relation,
@@ -126,6 +137,7 @@ def all_required_relations(
     triggerer_relation,
     dag_processor_relation,
     peer_relation,
+    airflow_api_server_requires_relation,
 ):
     return [
         postgres_relation,
@@ -134,6 +146,7 @@ def all_required_relations(
         triggerer_relation,
         dag_processor_relation,
         peer_relation,
+        airflow_api_server_requires_relation,
     ]
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -35,9 +35,7 @@ def test_container_not_ready(
 
     state_out = context.run(context.on.start(), state)
 
-    assert state_out.unit_status == ops.WaitingStatus(
-        constants.WAITING_FOR_CONTAINER_MESSAGE
-    )
+    assert state_out.unit_status == ops.WaitingStatus(constants.WAITING_FOR_CONTAINER_MESSAGE)
 
 
 def test_missing_postgres_relation(
@@ -80,6 +78,63 @@ def test_missing_postgres_relation_data(
 
     assert state_out.unit_status == ops.WaitingStatus(
         constants.WAITING_FOR_DATABASE_TO_BE_CREATED_MESSAGE
+    )
+
+    for relation in state_out.get_relations("airflow-coordinator"):
+        assert relation.local_app_data == {}
+
+
+def test_missing_airflow_api_server_requires_relation(
+    context,
+    state,
+    all_required_relations,
+    airflow_api_server_requires_relation,
+    mock_command_executor,
+):
+    all_required_relations.remove(airflow_api_server_requires_relation)
+    state = dataclasses.replace(state, relations=all_required_relations)
+
+    state_out = context.run(context.on.start(), state)
+
+    assert state_out.unit_status == ops.BlockedStatus(
+        constants.WAITING_FOR_API_SERVER_RELATION_MESSAGE
+    )
+
+    failures = json.dumps(
+        [
+            {
+                "component": "coordinator",
+                "code": airflow_coordinator.AirflowCoreValidationErrorEnum.WAITING_FOR_DEPENDENCIES,  # noqa: E501
+            }
+        ]
+    )
+
+    for relation in state_out.get_relations("airflow-coordinator"):
+        assert relation.local_app_data == {
+            "validation-failures": failures,
+        }
+
+
+def test_missing_airflow_api_server_requires_relation_data(
+    context,
+    state,
+    all_required_relations,
+    airflow_api_server_requires_relation,
+    mock_command_executor,
+):
+    missing_data_relation = dataclasses.replace(
+        airflow_api_server_requires_relation, remote_app_data={}
+    )
+
+    all_required_relations.remove(airflow_api_server_requires_relation)
+    all_required_relations.append(missing_data_relation)
+
+    state = dataclasses.replace(state, relations=all_required_relations)
+
+    state_out = context.run(context.on.start(), state)
+
+    assert state_out.unit_status == ops.WaitingStatus(
+        constants.WAITING_FOR_API_SERVER_HOST_PORT_MESSAGE
     )
 
     for relation in state_out.get_relations("airflow-coordinator"):
@@ -225,9 +280,7 @@ def test_db_migration_does_not_run_on_state_true(
     peer_relation_with_state = dataclasses.replace(
         peer_relation, local_app_data={"db_migration_ran": "true"}
     )
-    relations = [
-        r for r in all_required_relations if r.endpoint != constants.PEER_RELATION_NAME
-    ]
+    relations = [r for r in all_required_relations if r.endpoint != constants.PEER_RELATION_NAME]
     relations.append(peer_relation_with_state)
 
     with unittest.mock.patch(
@@ -279,13 +332,9 @@ def test_db_migration_runs_on_state_false(
     mock_run_db_migrate.assert_called_once()
 
 
-def test_db_migration_failure(
-    context, state, mock_command_executor, workload_container
-):
-    mock_command_executor["run_db_migrate"].return_value = (
-        command_executor.CommandExecutionResult(
-            success=False, stdout="", stderr="Migration failed", return_code=1
-        )
+def test_db_migration_failure(context, state, mock_command_executor, workload_container):
+    mock_command_executor["run_db_migrate"].return_value = command_executor.CommandExecutionResult(
+        success=False, stdout="", stderr="Migration failed", return_code=1
     )
 
     with unittest.mock.patch(
@@ -296,9 +345,7 @@ def test_db_migration_failure(
     ):
         state_out = context.run(context.on.pebble_ready(workload_container), state)
 
-    assert state_out.unit_status == ops.BlockedStatus(
-        constants.DB_MIGRATION_FAILED_MESSAGE
-    )
+    assert state_out.unit_status == ops.BlockedStatus(constants.DB_MIGRATION_FAILED_MESSAGE)
 
     # Verify that config was not distributed to core charms
     for relation in state_out.get_relations("airflow-coordinator"):


### PR DESCRIPTION
## Description
Counterpart of https://github.com/canonical/airflow-core-operators/pull/23

<!-- Summary of the changes in this PR -->
Imports `airflow-api-server` relation charm lib
Adds `airflow-api-server` as a requires
Uses the above charm lib to obtain api server host+port and use it to compose and set `base_url` in generated `airflow.cfg`
Adds unit tests to check added reconcile event handler checks
Modifies integration test mock charm to support `airflow_api_server` interface relation
Modifies integration test to ensure `base_url` is set after relation with mock api server over `airflow-api-server` endpoint added  

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [x] Integration tests added or updated
- [ ] Documentation updated
