### PR TITLE
[WF-296] Adding Terraform module with test and CI

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,13 @@
+name: Terraform checks
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  pull-request-terraform-checks:
+    name: PR Terraform checks
+    uses: canonical/workflows-team/.github/workflows/terraform.yaml@main

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,64 @@
+# Terraform module for Airflow Coordinator
+
+This module deploys the Airflow Coordinator charm using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For provider details, see the [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs).
+
+## Requirements
+- Terraform >= 1.12.2
+- Provider: `juju` >= 1.0.0
+- A Juju model must exist (see [Usage](#usage))
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name` | string | Name of the deployed application | False |
+| `channel` | string | Channel that the charm is deployed from | False |
+| `config` | map(string) | Map of the charm configuration options | False |
+| `constraints` | string | Constraints to deploy the charm with | False |
+| `model_uuid` | string | UUID of the model that the charm is deployed on | True |
+| `revision` | number | Revision number of the charm name | False |
+| `units` | number | Number of units to deploy | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `application` | Deployed application object |
+| `provides` | Map of `provides` endpoints |
+| `requires` | Map of `requires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_uuid` input a reference to the `juju_model` resource's UUID. For example:
+
+```
+resource "juju_model" "testing" {
+  name = "airflow"
+}
+
+module "airflow-coordinator-k8s" {
+  source     = "<path-to-this-directory>"
+  model_uuid = juju_model.testing.uuid
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_uuid` input a reference to the `data.juju_model` resource's UUID. This will enable Terraform to look for a `juju_model` resource with a UUID attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+
+```
+data "juju_model" "testing" {
+  uuid = var.model_uuid
+}
+
+module "airflow-coordinator-k8s" {
+  source     = "<path-to-this-directory>"
+  model_uuid = data.juju_model.testing.uuid
+}
+```

--- a/terraform/justfile
+++ b/terraform/justfile
@@ -1,0 +1,67 @@
+set export := true # Just variables are exported into environment variables
+
+[private]
+default:
+    just --list
+
+[private]
+initialize:
+    #!/usr/bin/bash
+    if [ ! -d ".terraform" ]; then
+        terraform init
+    fi
+
+[private]
+destroy-model:
+    juju destroy-model --no-prompt --destroy-storage terraform || true
+
+[private]
+add-model: (destroy-model)
+    juju add-model terraform
+
+[private]
+validate_test_tfvars variables_file:
+    #!/usr/bin/bash
+    MODEL_UUID=$(juju show-model terraform --format=json | jq -r '.terraform["model-uuid"]')
+    if ! juju show-model "${MODEL_UUID}" >/dev/null 2>&1; then
+        exit 1
+    fi
+    echo "model_uuid = \"${MODEL_UUID}\"" >> "${variables_file}"
+
+# Run terraform format
+fmt: (initialize)
+    terraform fmt
+
+# Run terraform validate
+validate: (initialize)
+    terraform validate
+
+# Run tflint
+lint:
+    tflint
+
+# Apply the terraform plan with the provided variables file
+apply variables_file: (initialize)
+    terraform apply -auto-approve -var-file="${variables_file}"
+
+# Destroy the terraform plan with the provided variables file
+destroy variables_file:
+    #!/usr/bin/bash
+    terraform destroy -auto-approve -var-file="${variables_file}"
+
+    just destroy-model
+    sed '/model_uuid/d' -i "${variables_file}"
+
+test:
+    #!/usr/bin/bash
+    set -euxo pipefail
+
+    trap 'just destroy "./test/test.tfvars"' EXIT
+
+    just add-model
+
+    just validate_test_tfvars "./test/test.tfvars"
+
+    just apply "./test/test.tfvars"
+
+    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Missing integration with postgres'))"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,15 @@
+resource "juju_application" "airflow_coordinator_k8s" {
+  name       = var.app_name
+  model_uuid = var.model_uuid
+
+  charm {
+    name     = "airflow-coordinator-k8s"
+    revision = var.revision
+    channel  = var.channel
+  }
+
+  constraints = var.constraints
+  config      = var.config
+
+  units = var.units
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,16 @@
+# CC008: charm modules must output the deployed application object.
+output "application" {
+  value = juju_application.airflow_coordinator_k8s
+}
+
+output "provides" {
+  value = {
+    airflow_coordinator = "airflow-coordinator"
+  }
+}
+
+output "requires" {
+  value = {
+    postgres = "postgres"
+  }
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,2 @@
+# CC008: include explicit provider block for a consistent module layout.
+provider "juju" {}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,10 @@
+# CC008: terraform block with explicit required providers and versions.
+terraform {
+  required_version = ">= 1.12.2"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = ">= 1.0.0"
+    }
+  }
+}

--- a/terraform/test/test.tfvars
+++ b/terraform/test/test.tfvars
@@ -1,0 +1,1 @@
+channel = "3.1/edge"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,41 @@
+variable "app_name" {
+  type        = string
+  description = "Name of the deployed application"
+  default     = "airflow-coordinator-k8s"
+}
+
+variable "channel" {
+  type        = string
+  description = "Charmhub channel to deploy the charm from"
+  default     = "3.1/stable"
+}
+
+variable "config" {
+  type        = map(string)
+  description = "Configuration to deploy this application with"
+  default     = {}
+}
+
+# CC008: default constraints should be null for charm modules.
+variable "constraints" {
+  type        = string
+  description = "Constraints to be used when deploying this application"
+  default     = null
+}
+
+variable "model_uuid" {
+  type        = string
+  description = "UUID of Juju model where the application is to be deployed"
+}
+
+variable "revision" {
+  type        = number
+  description = "Revision of the charm to deploy"
+  default     = null
+}
+
+variable "units" {
+  type        = number
+  description = "Number of units to deploy with this name and configuration"
+  default     = 1
+}


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR adds terraform module for airflow-coordinator-charm compliant with the spec proposed - [Charm Terraform Standards](https://docs.google.com/document/d/1k1psLCfcf0Nr5KeVtWGFi9wmzhcg5AP9GVZTsRyVQSQ/edit?pli=1&tab=t.0).

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->
`just test`

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [x] Documentation updated
