### PR TITLE
[WF-293] Update coordinator lib skip unchanged airflow.cfg writes

### DIFF
--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -172,12 +172,46 @@ LIBPATCH = 3
 logger = logging.getLogger(__name__)
 
 
-def write_airflow_config(
+def airflow_config_needs_update(
     container: ops.Container,
     config_path: str,
     config_template: str,
     sensitive_data: dict[str, str],
 ) -> bool:
+    """Check whether the rendered Airflow config differs from the file currently on disk.
+
+    Args:
+        container: The Pebble container to check the config in.
+        config_path: Path to the config file to compare against.
+        config_template: The Jinja2 template string for the Airflow config.
+        sensitive_data: Dictionary of sensitive values to render in the template.
+
+    Returns:
+        bool: True if the config needs to be written (content differs or file absent), else False.
+
+    Raises:
+        RuntimeError: If unable to connect to the container.
+    """
+    if not container.can_connect():
+        raise RuntimeError("Cannot connect to workload container")
+
+    try:
+        config = jinja2.Environment().from_string(config_template).render(**sensitive_data)
+
+        if container.exists(config_path) and container.pull(config_path).read() == config:
+            return False
+
+        return True
+    except Exception as e:
+        raise RuntimeError(f"Failed to check Airflow config: {e}") from e
+
+
+def write_airflow_config(
+    container: ops.Container,
+    config_path: str,
+    config_template: str,
+    sensitive_data: dict[str, str],
+) -> None:
     """Render and write the Airflow config to a container.
 
     This utility function can be used by both the coordinator charm (for db migrations)
@@ -189,9 +223,6 @@ def write_airflow_config(
         config_template: The Jinja2 template string for the Airflow config.
         sensitive_data: Dictionary of sensitive values to render in the template.
 
-    Returns:
-        bool: True if the file content changed and was written, else False.
-
     Raises:
         RuntimeError: If unable to connect to the container or write the config.
     """
@@ -201,10 +232,6 @@ def write_airflow_config(
     try:
         config = jinja2.Template(config_template).render(**sensitive_data)
 
-        if container.exists(config_path) and container.pull(config_path).read() == config:
-            logger.info("Airflow config at %s is unchanged; skipping write", config_path)
-            return False
-
         container.push(
             config_path,
             config,
@@ -213,7 +240,6 @@ def write_airflow_config(
             make_dirs=True,
         )
         logger.info("Successfully wrote Airflow config to %s", config_path)
-        return True
     except Exception as e:
         raise RuntimeError(f"Failed to write Airflow config: {e}") from e
 
@@ -944,16 +970,43 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
             ]
         )
 
-    def write_airflow_config(self, config_path: str) -> bool:
-        """Render the Airflow config in the provided path in the workload container."""
-        provider_content = self._requirer_handler.provider_content
+    def _get_rendered_config(self) -> str:
+        """Render the Airflow config template, caching the result for this event lifecycle."""
+        if self._rendered_config_cache is None:
+            provider_content = self._requirer_handler.provider_content
+            self._rendered_config_cache = (
+                jinja2.Environment()
+                .from_string(provider_content.config_template)
+                .render(**json.loads(provider_content.sensitive_data))
+            )
+        return self._rendered_config_cache
 
-        return write_airflow_config(
-            self._workload_container,
+    def _get_on_disk_config(self, config_path: str) -> str | None:
+        """Read the on-disk config file content, caching the result for this event lifecycle."""
+        if config_path not in self._on_disk_config_cache:
+            if self._workload_container.exists(config_path):
+                self._on_disk_config_cache[config_path] = (
+                    self._workload_container.pull(config_path).read()
+                )
+            else:
+                self._on_disk_config_cache[config_path] = None
+        return self._on_disk_config_cache[config_path]
+
+    def airflow_config_needs_update(self, config_path: str) -> bool:
+        """Check whether the rendered Airflow config differs from the file currently on disk."""
+        return self._get_on_disk_config(config_path) != self._get_rendered_config()
+
+    def write_airflow_config(self, config_path: str) -> None:
+        """Render and write the Airflow config in the provided path in the workload container."""
+        rendered = self._get_rendered_config()
+        self._workload_container.push(
             config_path,
-            provider_content.config_template,
-            json.loads(provider_content.sensitive_data),
+            rendered,
+            user="root",
+            group="root",
+            make_dirs=True,
         )
+        logger.info("Successfully wrote Airflow config to %s", config_path)
 
     @property
     def can_write_kubernetes_executor_pod_spec(self) -> bool:

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -939,10 +939,8 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
     def airflow_config_needs_update(self, config_path: str) -> bool:
         """Check whether the rendered Airflow config differs from the file currently on disk."""
         provider_content = self._requirer_handler.provider_content
-        rendered_config = (
-            jinja2.Environment()
-            .from_string(provider_content.config_template)
-            .render(**json.loads(provider_content.sensitive_data))
+        rendered_config = jinja2.Template(provider_content.config_template).render(
+            **json.loads(provider_content.sensitive_data)
         )
 
         if self._workload_container.exists(config_path):

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -172,40 +172,6 @@ LIBPATCH = 3
 logger = logging.getLogger(__name__)
 
 
-def airflow_config_needs_update(
-    container: ops.Container,
-    config_path: str,
-    config_template: str,
-    sensitive_data: dict[str, str],
-) -> bool:
-    """Check whether the rendered Airflow config differs from the file currently on disk.
-
-    Args:
-        container: The Pebble container to check the config in.
-        config_path: Path to the config file to compare against.
-        config_template: The Jinja2 template string for the Airflow config.
-        sensitive_data: Dictionary of sensitive values to render in the template.
-
-    Returns:
-        bool: True if the config needs to be written (content differs or file absent), else False.
-
-    Raises:
-        RuntimeError: If unable to connect to the container.
-    """
-    if not container.can_connect():
-        raise RuntimeError("Cannot connect to workload container")
-
-    try:
-        config = jinja2.Environment().from_string(config_template).render(**sensitive_data)
-
-        if container.exists(config_path) and container.pull(config_path).read() == config:
-            return False
-
-        return True
-    except Exception as e:
-        raise RuntimeError(f"Failed to check Airflow config: {e}") from e
-
-
 def write_airflow_config(
     container: ops.Container,
     config_path: str,

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -177,7 +177,7 @@ def write_airflow_config(
     config_path: str,
     config_template: str,
     sensitive_data: dict[str, str],
-) -> None:
+) -> bool:
     """Render and write the Airflow config to a container.
 
     This utility function can be used by both the coordinator charm (for db migrations)
@@ -189,6 +189,9 @@ def write_airflow_config(
         config_template: The Jinja2 template string for the Airflow config.
         sensitive_data: Dictionary of sensitive values to render in the template.
 
+    Returns:
+        bool: True if the file content changed and was written, else False.
+
     Raises:
         RuntimeError: If unable to connect to the container or write the config.
     """
@@ -198,6 +201,12 @@ def write_airflow_config(
     try:
         config = jinja2.Template(config_template).render(**sensitive_data)
 
+        if container.exists(config_path):
+            current_config = container.pull(config_path).read()
+            if current_config == config:
+                logger.info(f"Airflow config at {config_path} is unchanged; skipping write")
+                return False
+
         container.push(
             config_path,
             config,
@@ -206,6 +215,7 @@ def write_airflow_config(
             make_dirs=True,
         )
         logger.info(f"Successfully wrote Airflow config to {config_path}")
+        return True
     except Exception as e:
         raise RuntimeError(f"Failed to write Airflow config: {e}") from e
 
@@ -936,11 +946,11 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
             ]
         )
 
-    def write_airflow_config(self, config_path: str) -> None:
+    def write_airflow_config(self, config_path: str) -> bool:
         """Render the Airflow config in the provided path in the workload container."""
         provider_content = self._requirer_handler.provider_content
 
-        write_airflow_config(
+        return write_airflow_config(
             self._workload_container,
             config_path,
             provider_content.config_template,

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -201,11 +201,9 @@ def write_airflow_config(
     try:
         config = jinja2.Template(config_template).render(**sensitive_data)
 
-        if container.exists(config_path):
-            current_config = container.pull(config_path).read()
-            if current_config == config:
-                logger.info(f"Airflow config at {config_path} is unchanged; skipping write")
-                return False
+        if container.exists(config_path) and container.pull(config_path).read() == config:
+            logger.info("Airflow config at %s is unchanged; skipping write", config_path)
+            return False
 
         container.push(
             config_path,
@@ -214,7 +212,7 @@ def write_airflow_config(
             group="root",
             make_dirs=True,
         )
-        logger.info(f"Successfully wrote Airflow config to {config_path}")
+        logger.info("Successfully wrote Airflow config to %s", config_path)
         return True
     except Exception as e:
         raise RuntimeError(f"Failed to write Airflow config: {e}") from e

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -165,7 +165,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 3
+LIBPATCH = 4
 
 # TODO: add your code here! Happy coding!
 
@@ -205,7 +205,7 @@ def write_airflow_config(
             group="root",
             make_dirs=True,
         )
-        logger.info("Successfully wrote Airflow config to %s", config_path)
+        logger.info(f"Successfully wrote Airflow config to {config_path}")
     except Exception as e:
         raise RuntimeError(f"Failed to write Airflow config: {e}") from e
 
@@ -936,43 +936,31 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
             ]
         )
 
-    def _get_rendered_config(self) -> str:
-        """Render the Airflow config template, caching the result for this event lifecycle."""
-        if self._rendered_config_cache is None:
-            provider_content = self._requirer_handler.provider_content
-            self._rendered_config_cache = (
-                jinja2.Environment()
-                .from_string(provider_content.config_template)
-                .render(**json.loads(provider_content.sensitive_data))
-            )
-        return self._rendered_config_cache
-
-    def _get_on_disk_config(self, config_path: str) -> str | None:
-        """Read the on-disk config file content, caching the result for this event lifecycle."""
-        if config_path not in self._on_disk_config_cache:
-            if self._workload_container.exists(config_path):
-                self._on_disk_config_cache[config_path] = (
-                    self._workload_container.pull(config_path).read()
-                )
-            else:
-                self._on_disk_config_cache[config_path] = None
-        return self._on_disk_config_cache[config_path]
-
     def airflow_config_needs_update(self, config_path: str) -> bool:
         """Check whether the rendered Airflow config differs from the file currently on disk."""
-        return self._get_on_disk_config(config_path) != self._get_rendered_config()
+        provider_content = self._requirer_handler.provider_content
+        rendered_config = (
+            jinja2.Environment()
+            .from_string(provider_content.config_template)
+            .render(**json.loads(provider_content.sensitive_data))
+        )
+
+        if self._workload_container.exists(config_path):
+            on_disk_config = self._workload_container.pull(config_path).read()
+        else:
+            on_disk_config = None
+
+        return on_disk_config != rendered_config
 
     def write_airflow_config(self, config_path: str) -> None:
         """Render and write the Airflow config in the provided path in the workload container."""
-        rendered = self._get_rendered_config()
-        self._workload_container.push(
-            config_path,
-            rendered,
-            user="root",
-            group="root",
-            make_dirs=True,
+        provider_content = self._requirer_handler.provider_content
+        write_airflow_config(
+            container=self._workload_container,
+            config_path=config_path,
+            config_template=provider_content.config_template,
+            sensitive_data=json.loads(provider_content.sensitive_data),
         )
-        logger.info("Successfully wrote Airflow config to %s", config_path)
 
     @property
     def can_write_kubernetes_executor_pod_spec(self) -> bool:

--- a/tests/unit/test_airflow_coordinator.py
+++ b/tests/unit/test_airflow_coordinator.py
@@ -10,6 +10,7 @@ import logging
 import pathlib
 import tempfile
 import typing
+import unittest.mock
 
 import charms.airflow_coordinator_k8s.v0.airflow_coordinator as airflow_coordinator
 import ops
@@ -627,7 +628,7 @@ class TestAirflowCoordinatorCoreRequires:
 
             assert manager.charm.requirer.can_write_airflow_config
 
-            config_changed = manager.charm.requirer.write_airflow_config("/config/path")
+            manager.charm.requirer.write_airflow_config("/config/path")
 
             filesystem = state_out.get_container("workload-container").get_filesystem(
                 application_context
@@ -639,42 +640,88 @@ class TestAirflowCoordinatorCoreRequires:
             assert config_file_path.is_file()
             assert config_file_path.read_text(encoding="utf-8") == "test-config: s3cret"
             assert config_file_path.stat().st_mode & 0o777 == 0o644
-            assert config_changed
+
+    def test_airflow_config_needs_update_returns_true_when_config_absent(
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
+    ):
+        """Return True when the config file does not yet exist on disk."""
+        with application_context(
+            application_context.on.relation_changed(application_airflow_coordinator_relation),
+            application_state,
+        ) as manager:
+            manager.run()
+
+            assert manager.charm.requirer.airflow_config_needs_update("/config/path")
+
+    def test_airflow_config_needs_update_returns_false_when_config_unchanged(
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
+    ):
+        """Return False when the rendered config matches the file already on disk."""
+        with application_context(
+            application_context.on.relation_changed(application_airflow_coordinator_relation),
+            application_state,
+        ) as manager:
+            manager.run()
+
+            manager.charm.requirer.write_airflow_config("/config/path")
+            assert not manager.charm.requirer.airflow_config_needs_update("/config/path")
+
+    def test_airflow_config_needs_update_returns_true_when_config_changed(
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
+    ):
+        """Return True when the rendered config differs from the file already on disk."""
+        with application_context(
+            application_context.on.relation_changed(application_airflow_coordinator_relation),
+            application_state,
+        ) as manager:
+            manager.run()
+
+            manager.charm.unit.get_container("workload-container").push(
+                "/config/path",
+                "test-config: old-value",
+                make_dirs=True,
+            )
+
+            assert manager.charm.requirer.airflow_config_needs_update("/config/path")
 
     @pytest.mark.parametrize(
-        "file_exists, existing_content, expected_changed, expect_push",
+        "file_exists, existing_content, expected_needs_update",
         [
-            pytest.param(True, "test-config: s3cret", False, False, id="unchanged"),
-            pytest.param(True, "test-config: old", True, True, id="content_changes"),
-            pytest.param(False, None, True, True, id="file_missing"),
+            pytest.param(True, "test-config: s3cret", False, id="unchanged"),
+            pytest.param(True, "test-config: old", True, id="content_changes"),
+            pytest.param(False, None, True, id="file_missing"),
         ],
     )
-    def test_write_airflow_config_idempotent(
-        self, file_exists, existing_content, expected_changed, expect_push
+    def test_airflow_config_needs_update(
+        self, file_exists, existing_content, expected_needs_update
     ):
-        """Write config only when content differs; return True if written, False otherwise."""
-        from unittest.mock import Mock
-
-        pulled_file = Mock()
+        """Return True when config differs from disk or file is absent, False when unchanged."""
+        pulled_file = unittest.mock.Mock()
         pulled_file.read.return_value = existing_content
 
-        container = Mock()
+        container = unittest.mock.Mock()
         container.can_connect.return_value = True
         container.exists.return_value = file_exists
         container.pull.return_value = pulled_file
 
-        changed = airflow_coordinator.write_airflow_config(
+        needs_update = airflow_coordinator.airflow_config_needs_update(
             container=container,
             config_path="/config/path",
             config_template="test-config: {{ secret }}",
             sensitive_data={"secret": "s3cret"},
         )
 
-        assert changed is expected_changed
-        if expect_push:
-            container.push.assert_called_once()
-        else:
-            container.push.assert_not_called()
+        assert needs_update is expected_needs_update
+        container.push.assert_not_called()
 
     def test_can_write_airflow_config_blocked_by_mismatched_airflow_version(
         self,

--- a/tests/unit/test_airflow_coordinator.py
+++ b/tests/unit/test_airflow_coordinator.py
@@ -641,35 +641,27 @@ class TestAirflowCoordinatorCoreRequires:
             assert config_file_path.stat().st_mode & 0o777 == 0o644
             assert config_changed
 
-    def test_write_airflow_config_returns_false_when_unchanged(self):
-        """Skip write and return False when rendered config is unchanged."""
+    @pytest.mark.parametrize(
+        "file_exists, existing_content, expected_changed, expect_push",
+        [
+            pytest.param(True, "test-config: s3cret", False, False, id="unchanged"),
+            pytest.param(True, "test-config: old", True, True, id="content_changes"),
+            pytest.param(False, None, True, True, id="file_missing"),
+        ],
+    )
+    def test_write_airflow_config_idempotent(
+        self, file_exists, existing_content, expected_changed, expect_push
+    ):
+        """Write config only when content differs; return True if written, False otherwise."""
+        from unittest.mock import Mock
 
-        class _PulledFile:
-            def __init__(self, content: str):
-                self._content = content
+        pulled_file = Mock()
+        pulled_file.read.return_value = existing_content
 
-            def read(self):
-                return self._content
-
-        class _FakeContainer:
-            def __init__(self, existing_content: str):
-                self._existing_content = existing_content
-                self.push_calls = 0
-
-            def can_connect(self):
-                return True
-
-            def exists(self, path: str):
-                return path == "/config/path"
-
-            def pull(self, path: str):
-                assert path == "/config/path"
-                return _PulledFile(self._existing_content)
-
-            def push(self, *_args, **_kwargs):
-                self.push_calls += 1
-
-        container = _FakeContainer(existing_content="test-config: s3cret")
+        container = Mock()
+        container.can_connect.return_value = True
+        container.exists.return_value = file_exists
+        container.pull.return_value = pulled_file
 
         changed = airflow_coordinator.write_airflow_config(
             container=container,
@@ -678,51 +670,11 @@ class TestAirflowCoordinatorCoreRequires:
             sensitive_data={"secret": "s3cret"},
         )
 
-        assert not changed
-        assert container.push_calls == 0
-
-    def test_write_airflow_config_returns_true_when_content_changes(self):
-        """Write and return True when rendered config content changes."""
-
-        class _PulledFile:
-            def __init__(self, content: str):
-                self._content = content
-
-            def read(self):
-                return self._content
-
-        class _FakeContainer:
-            def __init__(self, existing_content: str):
-                self._existing_content = existing_content
-                self.push_calls = 0
-                self.last_pushed_content = None
-
-            def can_connect(self):
-                return True
-
-            def exists(self, path: str):
-                return path == "/config/path"
-
-            def pull(self, path: str):
-                assert path == "/config/path"
-                return _PulledFile(self._existing_content)
-
-            def push(self, _path: str, content: str, **_kwargs):
-                self.push_calls += 1
-                self.last_pushed_content = content
-
-        container = _FakeContainer(existing_content="test-config: old")
-
-        changed = airflow_coordinator.write_airflow_config(
-            container=container,
-            config_path="/config/path",
-            config_template="test-config: {{ secret }}",
-            sensitive_data={"secret": "s3cret"},
-        )
-
-        assert changed
-        assert container.push_calls == 1
-        assert container.last_pushed_content == "test-config: s3cret"
+        assert changed is expected_changed
+        if expect_push:
+            container.push.assert_called_once()
+        else:
+            container.push.assert_not_called()
 
     def test_can_write_airflow_config_blocked_by_mismatched_airflow_version(
         self,

--- a/tests/unit/test_airflow_coordinator.py
+++ b/tests/unit/test_airflow_coordinator.py
@@ -10,7 +10,6 @@ import logging
 import pathlib
 import tempfile
 import typing
-import unittest.mock
 
 import charms.airflow_coordinator_k8s.v0.airflow_coordinator as airflow_coordinator
 import ops

--- a/tests/unit/test_airflow_coordinator.py
+++ b/tests/unit/test_airflow_coordinator.py
@@ -627,7 +627,7 @@ class TestAirflowCoordinatorCoreRequires:
 
             assert manager.charm.requirer.can_write_airflow_config
 
-            manager.charm.requirer.write_airflow_config("/config/path")
+            config_changed = manager.charm.requirer.write_airflow_config("/config/path")
 
             filesystem = state_out.get_container("workload-container").get_filesystem(
                 application_context
@@ -639,6 +639,90 @@ class TestAirflowCoordinatorCoreRequires:
             assert config_file_path.is_file()
             assert config_file_path.read_text(encoding="utf-8") == "test-config: s3cret"
             assert config_file_path.stat().st_mode & 0o777 == 0o644
+            assert config_changed
+
+    def test_write_airflow_config_returns_false_when_unchanged(self):
+        """Skip write and return False when rendered config is unchanged."""
+
+        class _PulledFile:
+            def __init__(self, content: str):
+                self._content = content
+
+            def read(self):
+                return self._content
+
+        class _FakeContainer:
+            def __init__(self, existing_content: str):
+                self._existing_content = existing_content
+                self.push_calls = 0
+
+            def can_connect(self):
+                return True
+
+            def exists(self, path: str):
+                return path == "/config/path"
+
+            def pull(self, path: str):
+                assert path == "/config/path"
+                return _PulledFile(self._existing_content)
+
+            def push(self, *_args, **_kwargs):
+                self.push_calls += 1
+
+        container = _FakeContainer(existing_content="test-config: s3cret")
+
+        changed = airflow_coordinator.write_airflow_config(
+            container=container,
+            config_path="/config/path",
+            config_template="test-config: {{ secret }}",
+            sensitive_data={"secret": "s3cret"},
+        )
+
+        assert not changed
+        assert container.push_calls == 0
+
+    def test_write_airflow_config_returns_true_when_content_changes(self):
+        """Write and return True when rendered config content changes."""
+
+        class _PulledFile:
+            def __init__(self, content: str):
+                self._content = content
+
+            def read(self):
+                return self._content
+
+        class _FakeContainer:
+            def __init__(self, existing_content: str):
+                self._existing_content = existing_content
+                self.push_calls = 0
+                self.last_pushed_content = None
+
+            def can_connect(self):
+                return True
+
+            def exists(self, path: str):
+                return path == "/config/path"
+
+            def pull(self, path: str):
+                assert path == "/config/path"
+                return _PulledFile(self._existing_content)
+
+            def push(self, _path: str, content: str, **_kwargs):
+                self.push_calls += 1
+                self.last_pushed_content = content
+
+        container = _FakeContainer(existing_content="test-config: old")
+
+        changed = airflow_coordinator.write_airflow_config(
+            container=container,
+            config_path="/config/path",
+            config_template="test-config: {{ secret }}",
+            sensitive_data={"secret": "s3cret"},
+        )
+
+        assert changed
+        assert container.push_calls == 1
+        assert container.last_pushed_content == "test-config: s3cret"
 
     def test_can_write_airflow_config_blocked_by_mismatched_airflow_version(
         self,

--- a/tests/unit/test_airflow_coordinator.py
+++ b/tests/unit/test_airflow_coordinator.py
@@ -692,36 +692,6 @@ class TestAirflowCoordinatorCoreRequires:
 
             assert manager.charm.requirer.airflow_config_needs_update("/config/path")
 
-    @pytest.mark.parametrize(
-        "file_exists, existing_content, expected_needs_update",
-        [
-            pytest.param(True, "test-config: s3cret", False, id="unchanged"),
-            pytest.param(True, "test-config: old", True, id="content_changes"),
-            pytest.param(False, None, True, id="file_missing"),
-        ],
-    )
-    def test_airflow_config_needs_update(
-        self, file_exists, existing_content, expected_needs_update
-    ):
-        """Return True when config differs from disk or file is absent, False when unchanged."""
-        pulled_file = unittest.mock.Mock()
-        pulled_file.read.return_value = existing_content
-
-        container = unittest.mock.Mock()
-        container.can_connect.return_value = True
-        container.exists.return_value = file_exists
-        container.pull.return_value = pulled_file
-
-        needs_update = airflow_coordinator.airflow_config_needs_update(
-            container=container,
-            config_path="/config/path",
-            config_template="test-config: {{ secret }}",
-            sensitive_data={"secret": "s3cret"},
-        )
-
-        assert needs_update is expected_needs_update
-        container.push.assert_not_called()
-
     def test_can_write_airflow_config_blocked_by_mismatched_airflow_version(
         self,
         application_context,


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This change updates the Airflow Coordinator shared charm library to detect whether rendered `airflow.cfg` content actually changed before writing to the workload container.

Changes included:
- `write_airflow_config()` now compares existing file content with rendered content
- file write is skipped when content is unchanged
- function now returns `bool`:
  - `True` when content changed and file was written
  - `False` when content was unchanged and write was skipped
- `AirflowCoordinatorRequires.write_airflow_config()` now returns that `bool` to callers
- `LIBPATCH` is bumped to publish the updated library revision


<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Related to canonical/airflow-core-operators#19

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->
1. Build & deploy coordinator + all four core charms.
2. Ensure all required integrations are present and model is active.
3. Capture baseline service processes:
```
juju ssh --container airflow-api-server airflow-api-server-k8s/0 "pgrep -fa 'airflow api_server'"
juju ssh --container airflow-scheduler airflow-scheduler-k8s/0 "pgrep -fa 'airflow scheduler'"
juju ssh --container airflow-dag-processor airflow-dag-processor-k8s/0 "pgrep -fa 'airflow dag-processor'"
juju ssh --container airflow-triggerer airflow-triggerer-k8s/0 "pgrep -fa 'airflow triggerer'"
```
4. Trigger config change from coordinator:
Edit coordinator airflow_config.j2 (example:change  load_examples=False to True)

5. Repack and refresh coordinator:
```
juju refresh airflow-coordinator-k8s --path <local-airflow-coordinator-k8s.charm> --resource airflow-coordinator-image=ubuntu/airflow:3.1-24.04_edge
```
Verify change applied and workloads restarted.
Expected:
- Updated config value is present across core charms.
- Core workload processes changed from baseline after real config change.

7. Verify no-op refresh does not restart
Repack/refresh coordinator again without changing template.
Re-check process IDs and service state.
Expected:
- No new config write for unchanged content.
- Core workload processes remain stable on no-op refresh

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [X] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
