### PR TITLE
refactor: enable more generic configuration passing using the airflow_coordinator library

### DIFF
--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -165,7 +165,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 # TODO: add your code here! Happy coding!
 

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -824,7 +824,6 @@ class AirflowCoordinatorRequires(ops.Object):
         Args:
             config_path: the path where the configuration file will be saved.
         """
-
         provider_content = self.provider_content
         config = jinja2.Template(provider_content.config_template).render(
             **json.loads(provider_content.sensitive_data)

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -812,7 +812,7 @@ class AirflowCoordinatorRequires(ops.Object):
         This check ensures the coordinator has shared relevant config data
         in the relation and that the relation exists.
         """
-        content = self._requirer_handler.provider_content
+        content = self.provider_content
         return bool(content and content.config_template and content.sensitive_data)
 
     def write_airflow_config(self, config_path: str) -> None:
@@ -825,7 +825,7 @@ class AirflowCoordinatorRequires(ops.Object):
             config_path: the path where the configuration file will be saved.
         """
 
-        provider_content = self._requirer_handler.provider_content
+        provider_content = self.provider_content
         config = jinja2.Template(provider_content.config_template).render(
             **json.loads(provider_content.sensitive_data)
         )

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -11,9 +11,50 @@ retrieval of fields in pydantic models in the databag if plaintext, and in a
 juju secret if sensitive. We expand upon the implementation approach established
 in data_interfaces v1.
 
-### Requirer Charm
+### Requirer Charms
 
-The following presents an example usage of the AirflowCoordinatorRequires class:
+Two requirer classes are provided depending on the nature of the charm.
+
+**`AirflowCoordinatorRequires`** is the base class for charms that consume the
+coordinator relation but do not run an Airflow workload in a sidecar container
+(e.g. the coordinator charm itself running DB migrations). It writes the rendered
+Airflow config directly to the local filesystem via `pathlib`.
+
+```python
+import charms.airflow_coordinator_k8s.v0.airflow_coordinator as airflow_coordinator
+
+class AirflowRequirerCharm(ops.CharmBase):
+    def __init__(self, *args) -> None:
+        super().__init__(*args)
+
+        self.requirer = airflow_coordinator.AirflowCoordinatorRequires(
+            self,
+            "airflow-coordinator", # relation endpoint
+            callback=self.reconcile,
+        )
+
+    def reconcile(self, event) -> None:
+        # Determine current state of charm, what it should be, and how to get there
+```
+
+`AirflowCoordinatorRequires` surfaces the following:
+1. `provider_content`: the raw data shared by the coordinator charm
+2. `can_write_airflow_config`: True when the coordinator has shared a config
+template and sensitive data
+3. `write_airflow_config(filepath)`: renders and writes the Airflow config to
+a local filesystem path
+
+`AirflowCoordinatorRequires` will invoke the provided `callback` when:
+- the coordinator charm first shares the airflow config
+- the coordinator charm updates anything that affects the airflow config
+- the relation with the coordinator charm is broken or joined
+
+---
+
+**`AirflowCoordinatorCoreRequires`** extends `AirflowCoordinatorRequires` for
+Airflow core charms (Scheduler, API Server, Triggerer, DAG Processor). It adds
+pebble workload container awareness, metadata registration, and validation
+failure handling.
 
 ```python
 import charms.airflow_coordinator_k8s.v0.airflow_coordinator as airflow_coordinator
@@ -22,7 +63,7 @@ class AirflowCoreCharm(ops.CharmBase):
     def __init__(self, *args) -> None:
         super().__init__(*args)
 
-        self.requirer = airflow_coordinator.AirflowCoordinatorRequires(
+        self.requirer = airflow_coordinator.AirflowCoordinatorCoreRequires(
             self,
             "airflow-coordinator", # relation endpoint
             component="scheduler", # the component this charm represents
@@ -34,21 +75,23 @@ class AirflowCoreCharm(ops.CharmBase):
         # Determine current state of charm, what it should be, and how to get there
 ```
 
-The AirflowCoordinatorRequires surfaces the following:
-1. `ready`: indicates whether the relation is ready and config available in databag
-2. `airflow_core_validation_failures`: all Airflow Core charm validation failures in the cluster.
-3. `validation_failure_messages`: all validation failures for this charm
+`AirflowCoordinatorCoreRequires` surfaces everything from
+`AirflowCoordinatorRequires`, plus:
+1. `_ready`: indicates whether the relation is ready and config available in databag
+2. `airflow_core_validation_failures`: all Airflow Core charm validation failures
+in the cluster
+3. `validation_failure_messages`: all validation failures specific to this charm
 4. `missing_core_components_exist`: if any core charms are missing in the cluster
-5. `can_write_airflow_config`: all prerequisites met to be able to render and
-write airflow config file
-6. `write_airflow_config(filepath)`: renders and writes the airflow config in
-the workload container
+5. `can_write_airflow_config`: extends the base check to also require pebble
+connectivity and the absence of validation errors
+6. `write_airflow_config(filepath)`: renders and writes the Airflow config into
+the pebble workload container
 7. `can_write_kubernetes_executor_pod_spec`: all prerequisites met to be able
 to render and write the k8s executor pod spec
-8. `write_kubernetes_pod_spec(filepath)`: renders and write the k8s executor
-pod spec in the workload container
+8. `write_kubernetes_executor_pod_spec(filepath)`: renders and writes the k8s
+executor pod spec into the pebble workload container
 
-The AirflowCoordinatorRequires will invoke the provided `callback` when:
+`AirflowCoordinatorCoreRequires` will invoke the provided `callback` when:
 - the coordinator charm shares validation failures for all related core charms
 - the coordinator charm first shares the airflow config and/or k8s executor
 pod spec files
@@ -67,7 +110,7 @@ class AirflowCoordinatorCharm(ops.CharmBase):
     def __init__(self, *args) -> None:
         super().__init__(*args)
 
-        self.requirer = airflow_coordinator.AirflowCoordinatorProvides(
+        self.provider = airflow_coordinator.AirflowCoordinatorProvides(
             self,
             "airflow-coordinator", # relation endpoint
             callback=self.reconcile,
@@ -86,11 +129,11 @@ amongst the related core charms
 count amongst the related core charms
 4. `are_airflow_versions_consistent`: whether airflow versions consistent amongst
 all required related core charms
-4. `are_workload_image_hashes_consistent`: whether workload image hashes are
+5. `are_workload_image_hashes_consistent`: whether workload image hashes are
 consistent amongst all required related core charms
-5. `set_validation_errors()`: set any validation errors in databags of all
+6. `set_validation_errors()`: set any validation errors in databags of all
 related core charms
-6. `set_airflow_config()`: set the airflow config, k8s executor pod spec if
+7. `set_airflow_config()`: set the airflow config, k8s executor pod spec if
 available, and sensitive data in databag + juju secret to share with all related
 core charms
 
@@ -152,7 +195,7 @@ def write_airflow_config(
         raise RuntimeError("Cannot connect to workload container")
 
     try:
-        config = jinja2.Environment().from_string(config_template).render(**sensitive_data)
+        config = jinja2.Template(config_template).render(**sensitive_data)
 
         container.push(
             config_path,
@@ -610,7 +653,7 @@ class AirflowCoordinatorProviderEventHandler(
         if not self.interface.relations:
             return
 
-        if not all([config_template, sensitive_data]):
+        if not config_template:
             return
 
         if not self.charm.unit.is_leader():
@@ -714,16 +757,14 @@ class AirflowCoordinatorRequires(ops.Object):
         self,
         charm: ops.CharmBase,
         relation_name: str,
-        component: str,
-        workload_container: ops.Container,
         callback: typing.Callable,
     ):
         self._charm = charm
         self._relation_name = relation_name
-        self._component = component
 
         if not charm.model.get_relation(relation_name):
-            self._charm.framework.observe(charm.on[relation_name].relation_broken, callback)
+            for event in self._no_relation_events():
+                self._charm.framework.observe(event, callback)
 
             return
 
@@ -733,8 +774,85 @@ class AirflowCoordinatorRequires(ops.Object):
             charm, relation_name, AirflowCoordinatorProviderModel
         )
 
-        self._workload_container = workload_container
+        self._on_handler_ready()
 
+        for event in self._relation_events():
+            self.framework.observe(event, callback)
+
+    def _no_relation_events(self) -> list:
+        """Events to observe when no relation exists."""
+        return [
+            self._charm.on[self._relation_name].relation_joined,
+            self._charm.on[self._relation_name].relation_broken,
+        ]
+
+    def _on_handler_ready(self) -> None:
+        """Called after the requirer handler is created. Override for extra setup."""
+        pass
+
+    def _relation_events(self) -> list:
+        """Events to observe when a relation exists."""
+        return [
+            self._requirer_handler.on.airflow_config_available,
+            self._requirer_handler.on.airflow_config_updated,
+            self._charm.on[self._relation_name].relation_joined,
+            self._charm.on[self._relation_name].relation_broken,
+        ]
+
+    @property
+    def provider_content(self) -> typing.Optional[AirflowCoordinatorProviderModel]:
+        """Data from the related Airflow Coordinator charm."""
+        return self._requirer_handler.provider_content
+
+    @property
+    def can_write_airflow_config(self) -> bool:
+        """Return True if it is safe to write the Airflow config to the container.
+
+        This check ensures the coordinator has shared relevant config data
+        in the relation and that the relation exists.
+        """
+        content = self._requirer_handler.provider_content
+        return bool(content and content.config_template and content.sensitive_data)
+
+    def write_airflow_config(self, config_path: str) -> None:
+        """Render the Airflow config and write it to a local filesystem path.
+
+        Writes to a plain filesystem path rather than a pebble workload container,
+        making it suitable for charms without a sidecar container.
+
+        Args:
+            config_path: the path where the configuration file will be saved.
+        """
+        import pathlib
+
+        provider_content = self._requirer_handler.provider_content
+        config = jinja2.Template(provider_content.config_template).render(
+            **json.loads(provider_content.sensitive_data)
+        )
+        path = pathlib.Path(config_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(config)
+
+
+class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
+    """A requirer handler for Airflow core charms."""
+
+    def __init__(
+        self,
+        charm: ops.CharmBase,
+        relation_name: str,
+        component: str,
+        workload_container: ops.Container,
+        callback: typing.Callable,
+    ):
+        self._component = component
+        self._workload_container = workload_container
+        super().__init__(charm, relation_name, callback)
+
+    def _no_relation_events(self) -> list:
+        return [self._charm.on[self._relation_name].relation_broken]
+
+    def _on_handler_ready(self) -> None:
         if self._workload_container.can_connect():
             # TODO: pull airflow_version and workload_image_hash from container
             # after https://github.com/canonical/airflow-rocks/issues/13 is resolved
@@ -745,17 +863,17 @@ class AirflowCoordinatorRequires(ops.Object):
                 metadata=AirflowCoordinatorRequirerModel(
                     airflow_version=airflow_version,
                     workload_image_hash=workload_image_hash,
-                    component=component,
+                    component=self._component,
                 )
             )
 
-        for event in [
+    def _relation_events(self) -> list:
+        return [
             self._requirer_handler.on.airflow_config_available,
             self._requirer_handler.on.airflow_config_updated,
             self._requirer_handler.on.airflow_core_metadata_validation_failed,
-            charm.on[relation_name].relation_broken,
-        ]:
-            self.framework.observe(event, callback)
+            self._charm.on[self._relation_name].relation_broken,
+        ]
 
     @property
     def _ready(self) -> bool:
@@ -848,11 +966,9 @@ class AirflowCoordinatorRequires(ops.Object):
         """Render the K8s executor pod spec in the provided path in the workload container."""
         provider_content = self._requirer_handler.provider_content
 
-        k8s_executor_pod_spec = (
-            jinja2.Environment()
-            .from_string(provider_content.kubernetes_executor_pod_spec)
-            .render(**json.loads(provider_content.sensitive_data))
-        )
+        k8s_executor_pod_spec = jinja2.Template(
+            provider_content.kubernetes_executor_pod_spec
+        ).render(**json.loads(provider_content.sensitive_data))
 
         self._workload_container.push(
             filepath,
@@ -1001,20 +1117,27 @@ class AirflowCoordinatorProvides(ops.Object):
 
     def set_airflow_config(
         self,
-        config_template: str,
+        config_template: typing.Optional[str] = None,
         k8s_executor_pod_spec_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
+        executor_config: typing.Optional[dict] = None,
     ) -> None:
         """Update config with related core charms.
 
         Args:
-            config_template: Airflow config (jinja template string)
-            k8s_executor_pod_spec_template: (optional) K8s executor pod spec template
+            config_template: Airflow config as a Jinja2 template string.
+            k8s_executor_pod_spec_template: (optional) K8s executor pod spec template.
             sensitive_data: sensitive data to render config of k8s executor pod
-                spec jinja templates with
+                spec jinja templates with.
+            executor_config: Airflow config as a dict of section -> key/value pairs
+                (e.g. {"executor": {"default_queue": "kubernetes"}}). Serialised to
+                JSON and stored in the relation databag. Takes precedence over
+                config_template when both are provided.
         """
+        template = json.dumps(executor_config) if executor_config is not None else config_template
+
         self._provider_handler.update_content(
-            config_template=config_template,
+            config_template=template,
             kubernetes_executor_pod_spec=k8s_executor_pod_spec_template,
             sensitive_data=sensitive_data,
         )

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -147,6 +147,7 @@ import collections
 import enum
 import json
 import logging
+import pathlib
 import pickle
 import typing
 
@@ -823,7 +824,6 @@ class AirflowCoordinatorRequires(ops.Object):
         Args:
             config_path: the path where the configuration file will be saved.
         """
-        import pathlib
 
         provider_content = self._requirer_handler.provider_content
         config = jinja2.Template(provider_content.config_template).render(

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -1119,7 +1119,6 @@ class AirflowCoordinatorProvides(ops.Object):
         config_template: typing.Optional[str] = None,
         k8s_executor_pod_spec_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
-        executor_config: typing.Optional[dict] = None,
     ) -> None:
         """Update config with related core charms.
 
@@ -1128,15 +1127,9 @@ class AirflowCoordinatorProvides(ops.Object):
             k8s_executor_pod_spec_template: (optional) K8s executor pod spec template.
             sensitive_data: sensitive data to render config of k8s executor pod
                 spec jinja templates with.
-            executor_config: Airflow config as a dict of section -> key/value pairs
-                (e.g. {"executor": {"default_queue": "kubernetes"}}). Serialised to
-                JSON and stored in the relation databag. Takes precedence over
-                config_template when both are provided.
         """
-        template = json.dumps(executor_config) if executor_config is not None else config_template
-
         self._provider_handler.update_content(
-            config_template=template,
+            config_template=config_template,
             kubernetes_executor_pod_spec=k8s_executor_pod_spec_template,
             sensitive_data=sensitive_data,
         )

--- a/tests/integration/mock-core-charm/src/charm.py
+++ b/tests/integration/mock-core-charm/src/charm.py
@@ -28,7 +28,7 @@ class MockCoreCharmCharm(ops.CharmBase):
             config in self.config
             for config in ["component", "airflow_version", "workload_image_hash"]
         ):
-            self.config_requirer = airflow_coordinator.AirflowCoordinatorRequires(
+            self.config_requirer = airflow_coordinator.AirflowCoordinatorCoreRequires(
                 self,
                 AIRFLOW_COORDINATOR_RELATION_NAME,
                 self.config["component"],

--- a/tests/unit/test_airflow_coordinator.py
+++ b/tests/unit/test_airflow_coordinator.py
@@ -8,6 +8,7 @@ import dataclasses
 import json
 import logging
 import pathlib
+import tempfile
 import typing
 
 import charms.airflow_coordinator_k8s.v0.airflow_coordinator as airflow_coordinator
@@ -382,41 +383,41 @@ class TestAirflowCoordinatorRequires:
         base_requires_context,
         base_application_state,
         application_airflow_coordinator_relation,
-        tmp_path,
     ):
-        config_path = str(tmp_path / "config" / "airflow.cfg")
+        with tempfile.NamedTemporaryFile(suffix=".cfg") as tmp_file:
+            config_path = tmp_file.name
 
-        with base_requires_context(
-            base_requires_context.on.relation_changed(
-                application_airflow_coordinator_relation
-            ),
-            base_application_state,
-        ) as manager:
-            manager.run()
-            manager.charm.requirer.write_airflow_config(config_path)
+            with base_requires_context(
+                base_requires_context.on.relation_changed(
+                    application_airflow_coordinator_relation
+                ),
+                base_application_state,
+            ) as manager:
+                manager.run()
+                manager.charm.requirer.write_airflow_config(config_path)
 
-        assert pathlib.Path(config_path).exists()
-        assert pathlib.Path(config_path).read_text() == "test-config: s3cret"
+            assert pathlib.Path(config_path).exists()
+            assert pathlib.Path(config_path).read_text() == "test-config: s3cret"
 
     def test_write_airflow_config_creates_parent_directories(
         self,
         base_requires_context,
         base_application_state,
         application_airflow_coordinator_relation,
-        tmp_path,
     ):
-        config_path = str(tmp_path / "deeply" / "nested" / "dir" / "airflow.cfg")
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config_path = str(pathlib.Path(tmp_dir) / "deeply" / "nested" / "dir" / "airflow.cfg")
 
-        with base_requires_context(
-            base_requires_context.on.relation_changed(
-                application_airflow_coordinator_relation
-            ),
-            base_application_state,
-        ) as manager:
-            manager.run()
-            manager.charm.requirer.write_airflow_config(config_path)
+            with base_requires_context(
+                base_requires_context.on.relation_changed(
+                    application_airflow_coordinator_relation
+                ),
+                base_application_state,
+            ) as manager:
+                manager.run()
+                manager.charm.requirer.write_airflow_config(config_path)
 
-        assert pathlib.Path(config_path).exists()
+            assert pathlib.Path(config_path).exists()
 
     def test_provider_content_returns_model_with_valid_data(
         self,

--- a/tests/unit/test_airflow_coordinator.py
+++ b/tests/unit/test_airflow_coordinator.py
@@ -20,13 +20,29 @@ logger = logging.getLogger(__name__)
 AIRFLOW_COORDINATOR_RELATION_INTERFACE = "airflow-coordinator"
 
 
-class AirflowCoreApplicationCharm(ops.CharmBase):
-    """Mock application charm to enable testing Airflow Coordinator charm libs."""
+class AirflowCoordinatorBaseRequiresCharm(ops.CharmBase):
+    """Mock charm using AirflowCoordinatorRequires (base class, no workload container)."""
 
     def __init__(self, *args):
         super().__init__(*args)
 
         self.requirer = airflow_coordinator.AirflowCoordinatorRequires(
+            self,
+            AIRFLOW_COORDINATOR_RELATION_INTERFACE,
+            callback=self.reconcile,
+        )
+
+    def reconcile(self, event) -> None:
+        logger.info(f"§BaseRequirer reacting to event: {type(event)}")
+
+
+class AirflowCoreApplicationCharm(ops.CharmBase):
+    """Mock core charm using AirflowCoordinatorCoreRequires."""
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self.requirer = airflow_coordinator.AirflowCoordinatorCoreRequires(
             self,
             AIRFLOW_COORDINATOR_RELATION_INTERFACE,
             component="scheduler",
@@ -77,31 +93,6 @@ class AirflowCoordianatorCharmWaiting(AirflowCoordianatorCharmBase):
 
     def dependencies_check_callable(self) -> bool:
         return False
-
-
-@pytest.fixture(scope="function")
-def application_context():
-    return ops.testing.Context(
-        charm_type=AirflowCoreApplicationCharm,
-        meta={
-            "name": "airflow-core-application",
-            "containers": {
-                "workload-container": {
-                    "resource": "workload-container-image",
-                    "channel": "latest/edge",
-                    "architectures": [
-                        "amd64",
-                    ],
-                },
-            },
-            "requires": {
-                "airflow-coordinator": {
-                    "interface": "airflow_coordinator",
-                    "limit": 1,
-                },
-            },
-        },
-    )
 
 
 @pytest.fixture(scope="function")
@@ -189,7 +180,63 @@ def valid_relation_data(coordinator_relation_secret):
 @pytest.fixture(scope="function")
 def application_airflow_coordinator_relation(valid_relation_data):
     return ops.testing.Relation(
-        "airflow-coordinator", interface="airflow_coordinator", remote_app_data=valid_relation_data
+        "airflow-coordinator",
+        interface="airflow_coordinator",
+        remote_app_data=valid_relation_data,
+    )
+
+
+@pytest.fixture(scope="function")
+def base_requires_context():
+    return ops.testing.Context(
+        charm_type=AirflowCoordinatorBaseRequiresCharm,
+        meta={
+            "name": "airflow-base-requires-application",
+            "requires": {
+                "airflow-coordinator": {
+                    "interface": "airflow_coordinator",
+                    "limit": 1,
+                },
+            },
+        },
+    )
+
+
+@pytest.fixture(scope="function")
+def base_application_state(
+    application_airflow_coordinator_relation,
+    coordinator_relation_secret,
+):
+    """State for the base requires charm — no workload container."""
+    return ops.testing.State(
+        leader=True,
+        relations=[application_airflow_coordinator_relation],
+        secrets=[coordinator_relation_secret],
+    )
+
+
+@pytest.fixture(scope="function")
+def application_context():
+    return ops.testing.Context(
+        charm_type=AirflowCoreApplicationCharm,
+        meta={
+            "name": "airflow-core-application",
+            "containers": {
+                "workload-container": {
+                    "resource": "workload-container-image",
+                    "channel": "latest/edge",
+                    "architectures": [
+                        "amd64",
+                    ],
+                },
+            },
+            "requires": {
+                "airflow-coordinator": {
+                    "interface": "airflow_coordinator",
+                    "limit": 1,
+                },
+            },
+        },
     )
 
 
@@ -246,7 +293,9 @@ def coordinator_waiting_context():
 
 
 def core_charm_relation(
-    component: str, airflow_version: str = "3.1.0", workload_image_hash: str = "somehash"
+    component: str,
+    airflow_version: str = "3.1.0",
+    workload_image_hash: str = "somehash",
 ) -> ops.testing.Relation:
     return ops.testing.Relation(
         "airflow-coordinator",
@@ -277,38 +326,188 @@ def generate_coordinator_state(
 
 
 class TestAirflowCoordinatorRequires:
+    def test_core_requires_is_subclass(self):
+        assert issubclass(
+            airflow_coordinator.AirflowCoordinatorCoreRequires,
+            airflow_coordinator.AirflowCoordinatorRequires,
+        )
+
+    def test_initializes_without_error_when_no_relation_exists(
+        self, base_requires_context
+    ):
+        """Charm initializes cleanly when no airflow-coordinator relation is present."""
+        state = ops.testing.State(leader=True)
+        state_out = base_requires_context.run(base_requires_context.on.start(), state)
+        assert state_out is not None
+
+    def test_can_write_airflow_config_with_valid_data(
+        self,
+        base_requires_context,
+        base_application_state,
+        application_airflow_coordinator_relation,
+    ):
+        with base_requires_context(
+            base_requires_context.on.relation_changed(
+                application_airflow_coordinator_relation
+            ),
+            base_application_state,
+        ) as manager:
+            manager.run()
+            assert manager.charm.requirer.can_write_airflow_config
+
+    def test_can_write_airflow_config_returns_false_with_no_content(
+        self,
+        base_requires_context,
+        application_airflow_coordinator_relation,
+        coordinator_relation_secret,
+    ):
+        empty_relation = dataclasses.replace(
+            application_airflow_coordinator_relation, remote_app_data={}
+        )
+        state = ops.testing.State(
+            leader=True,
+            relations=[empty_relation],
+            secrets=[coordinator_relation_secret],
+        )
+
+        with base_requires_context(
+            base_requires_context.on.relation_changed(empty_relation),
+            state,
+        ) as manager:
+            manager.run()
+            assert not manager.charm.requirer.can_write_airflow_config
+
+    def test_write_airflow_config_writes_to_local_filesystem(
+        self,
+        base_requires_context,
+        base_application_state,
+        application_airflow_coordinator_relation,
+        tmp_path,
+    ):
+        config_path = str(tmp_path / "config" / "airflow.cfg")
+
+        with base_requires_context(
+            base_requires_context.on.relation_changed(
+                application_airflow_coordinator_relation
+            ),
+            base_application_state,
+        ) as manager:
+            manager.run()
+            manager.charm.requirer.write_airflow_config(config_path)
+
+        assert pathlib.Path(config_path).exists()
+        assert pathlib.Path(config_path).read_text() == "test-config: s3cret"
+
+    def test_write_airflow_config_creates_parent_directories(
+        self,
+        base_requires_context,
+        base_application_state,
+        application_airflow_coordinator_relation,
+        tmp_path,
+    ):
+        config_path = str(tmp_path / "deeply" / "nested" / "dir" / "airflow.cfg")
+
+        with base_requires_context(
+            base_requires_context.on.relation_changed(
+                application_airflow_coordinator_relation
+            ),
+            base_application_state,
+        ) as manager:
+            manager.run()
+            manager.charm.requirer.write_airflow_config(config_path)
+
+        assert pathlib.Path(config_path).exists()
+
+    def test_provider_content_returns_model_with_valid_data(
+        self,
+        base_requires_context,
+        base_application_state,
+        application_airflow_coordinator_relation,
+    ):
+        with base_requires_context(
+            base_requires_context.on.relation_changed(
+                application_airflow_coordinator_relation
+            ),
+            base_application_state,
+        ) as manager:
+            manager.run()
+            content = manager.charm.requirer.provider_content
+            assert content is not None
+            assert content.config_template == "test-config: {{ secret }}"
+            assert content.kubernetes_executor_pod_spec == "test-pod-spec: {{ secret }}"
+
+    def test_provider_content_has_no_config_with_empty_databag(
+        self,
+        base_requires_context,
+        application_airflow_coordinator_relation,
+        coordinator_relation_secret,
+    ):
+        """All provider model fields are optional: an empty databag returns an all-None model."""
+        empty_relation = dataclasses.replace(
+            application_airflow_coordinator_relation, remote_app_data={}
+        )
+        state = ops.testing.State(
+            leader=True,
+            relations=[empty_relation],
+            secrets=[coordinator_relation_secret],
+        )
+
+        with base_requires_context(
+            base_requires_context.on.relation_changed(empty_relation),
+            state,
+        ) as manager:
+            manager.run()
+            content = manager.charm.requirer.provider_content
+            assert content is not None
+            assert content.config_template is None
+            assert content.sensitive_data is None
+
+
+class TestAirflowCoordinatorCoreRequires:
     def get_juju_log_line(self, log_level: str, event: ops.EventBase):
         return ops.testing.JujuLogLine(
             level=log_level, message=f"§Requirer reacting to event: {event}"
         )
 
     def test_airflow_core_validation_failures(
-        self, application_context, application_state, application_airflow_coordinator_relation
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
     ):
         with application_context(
-            application_context.on.relation_changed(application_airflow_coordinator_relation),
+            application_context.on.relation_changed(
+                application_airflow_coordinator_relation
+            ),
             application_state,
         ) as manager:
             manager.run()
             assert (
-                self.get_juju_log_line("INFO", airflow_coordinator.AirflowConfigAvailableEvent)
+                self.get_juju_log_line(
+                    "INFO", airflow_coordinator.AirflowConfigAvailableEvent
+                )
                 in application_context.juju_log
             )
 
             assert len(manager.charm.requirer.airflow_core_validation_failures) == 0
 
     def test_validation_failure_messages(
-        self, application_context, application_state, application_airflow_coordinator_relation
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
     ):
         with application_context(
-            application_context.on.relation_changed(application_airflow_coordinator_relation),
+            application_context.on.relation_changed(
+                application_airflow_coordinator_relation
+            ),
             application_state,
         ) as manager:
             manager.run()
 
             assert len(manager.charm.requirer.validation_failure_messages) == 0
 
-    def test_missing_postgres_relation(
+    def test_waiting_for_dependencies_sets_not_ready(
         self,
         application_context,
         application_state,
@@ -337,7 +536,9 @@ class TestAirflowCoordinatorRequires:
             assert sorted(manager.charm.requirer.validation_failure_messages) == [
                 failure["code"]
                 for failure in json.loads(
-                    coordinator_awaiting_dependencies_relation_data["validation-failures"]
+                    coordinator_awaiting_dependencies_relation_data[
+                        "validation-failures"
+                    ]
                 )
             ]
 
@@ -366,16 +567,19 @@ class TestAirflowCoordinatorRequires:
 
             assert sorted(manager.charm.requirer.airflow_core_validation_failures) == [
                 failure["code"]
-                for failure in json.loads(missing_components_relation_data["validation-failures"])
+                for failure in json.loads(
+                    missing_components_relation_data["validation-failures"]
+                )
             ]
 
-    def test_validation_failure_messages_with_missing_components_failures(
+    def test_validation_failure_messages_only_include_own_component(
         self,
         application_context,
         application_state,
         application_airflow_coordinator_relation,
         missing_components_relation_data,
     ):
+        """Only failures for the charm's component (scheduler) are surfaced."""
         relation_missing_commponents = dataclasses.replace(
             application_airflow_coordinator_relation,
             remote_app_data=missing_components_relation_data,
@@ -394,23 +598,29 @@ class TestAirflowCoordinatorRequires:
 
             assert sorted(manager.charm.requirer.validation_failure_messages) == [
                 failure["code"]
-                for failure in json.loads(missing_components_relation_data["validation-failures"])
+                for failure in json.loads(
+                    missing_components_relation_data["validation-failures"]
+                )
                 if failure["component"] == "scheduler"
             ]
 
-    def test_write_airflow_config(
+    def test_write_airflow_config_to_workload_container(
         self,
         application_context,
         application_state,
         application_airflow_coordinator_relation,
     ):
         with application_context(
-            application_context.on.relation_changed(application_airflow_coordinator_relation),
+            application_context.on.relation_changed(
+                application_airflow_coordinator_relation
+            ),
             application_state,
         ) as manager:
             state_out = manager.run()
             assert (
-                self.get_juju_log_line("INFO", airflow_coordinator.AirflowConfigAvailableEvent)
+                self.get_juju_log_line(
+                    "INFO", airflow_coordinator.AirflowConfigAvailableEvent
+                )
                 in application_context.juju_log
             )
 
@@ -429,7 +639,7 @@ class TestAirflowCoordinatorRequires:
             assert config_file_path.read_text(encoding="utf-8") == "test-config: s3cret"
             assert config_file_path.stat().st_mode & 0o777 == 0o644
 
-    def test_can_write_airflow_config_with_mismatched_airflow_version_failures(
+    def test_can_write_airflow_config_blocked_by_mismatched_airflow_version(
         self,
         application_context,
         application_state,
@@ -445,7 +655,9 @@ class TestAirflowCoordinatorRequires:
         )
 
         with application_context(
-            application_context.on.relation_changed(relation_mismatched_airflow_versions),
+            application_context.on.relation_changed(
+                relation_mismatched_airflow_versions
+            ),
             state_mismatched_airflow_versions,
         ) as manager:
             manager.run()
@@ -458,7 +670,7 @@ class TestAirflowCoordinatorRequires:
 
             assert not manager.charm.requirer.can_write_airflow_config
 
-    def test_can_write_airflow_config_with_mismatched_workload_image_hash(
+    def test_can_write_airflow_config_blocked_by_mismatched_workload_image_hash(
         self,
         application_context,
         application_state,
@@ -474,7 +686,9 @@ class TestAirflowCoordinatorRequires:
         )
 
         with application_context(
-            application_context.on.relation_changed(relation_mismatched_workload_image_hash),
+            application_context.on.relation_changed(
+                relation_mismatched_workload_image_hash
+            ),
             state_mismatched_airflow_versions,
         ) as manager:
             manager.run()
@@ -487,16 +701,67 @@ class TestAirflowCoordinatorRequires:
 
             assert not manager.charm.requirer.can_write_airflow_config
 
-    def test_write_k8s_executor_pod_spec(
-        self, application_context, application_state, application_airflow_coordinator_relation
+    def test_can_write_airflow_config_blocked_when_container_not_connectable(
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
+        application_workload_container,
+    ):
+        container_not_ready = dataclasses.replace(
+            application_workload_container, can_connect=False
+        )
+        state = dataclasses.replace(application_state, containers=[container_not_ready])
+
+        with application_context(
+            application_context.on.relation_changed(
+                application_airflow_coordinator_relation
+            ),
+            state,
+        ) as manager:
+            manager.run()
+            assert not manager.charm.requirer.can_write_airflow_config
+
+    def test_can_write_airflow_config_blocked_by_missing_core_components(
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
+        missing_components_relation_data,
+    ):
+        relation_missing_components = dataclasses.replace(
+            application_airflow_coordinator_relation,
+            remote_app_data=missing_components_relation_data,
+        )
+        state_missing_components = dataclasses.replace(
+            application_state, relations=[relation_missing_components]
+        )
+
+        with application_context(
+            application_context.on.relation_changed(relation_missing_components),
+            state_missing_components,
+        ) as manager:
+            manager.run()
+            assert manager.charm.requirer.missing_core_components_exist
+            assert not manager.charm.requirer.can_write_airflow_config
+
+    def test_write_k8s_executor_pod_spec_to_workload_container(
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
     ):
         with application_context(
-            application_context.on.relation_changed(application_airflow_coordinator_relation),
+            application_context.on.relation_changed(
+                application_airflow_coordinator_relation
+            ),
             application_state,
         ) as manager:
             state_out = manager.run()
             assert (
-                self.get_juju_log_line("INFO", airflow_coordinator.AirflowConfigAvailableEvent)
+                self.get_juju_log_line(
+                    "INFO", airflow_coordinator.AirflowConfigAvailableEvent
+                )
                 in application_context.juju_log
             )
 
@@ -510,14 +775,18 @@ class TestAirflowCoordinatorRequires:
                 application_context
             )
 
-            config_file_path = pathlib.Path(f"{filesystem.absolute()}/k8s_executor_pod_spec/path")
+            config_file_path = pathlib.Path(
+                f"{filesystem.absolute()}/k8s_executor_pod_spec/path"
+            )
 
             assert config_file_path.exists()
             assert config_file_path.is_file()
-            assert config_file_path.read_text(encoding="utf-8") == "test-pod-spec: s3cret"
+            assert (
+                config_file_path.read_text(encoding="utf-8") == "test-pod-spec: s3cret"
+            )
             assert config_file_path.stat().st_mode & 0o777 == 0o644
 
-    def test_can_write_k8s_executor_pod_spec_with_mismatched_airflow_version_failures(
+    def test_can_write_k8s_executor_pod_spec_blocked_by_mismatched_airflow_version(
         self,
         application_context,
         application_state,
@@ -533,7 +802,9 @@ class TestAirflowCoordinatorRequires:
         )
 
         with application_context(
-            application_context.on.relation_changed(relation_mismatched_airflow_versions),
+            application_context.on.relation_changed(
+                relation_mismatched_airflow_versions
+            ),
             state_mismatched_airflow_versions,
         ) as manager:
             manager.run()
@@ -546,7 +817,7 @@ class TestAirflowCoordinatorRequires:
 
             assert not manager.charm.requirer.can_write_kubernetes_executor_pod_spec
 
-    def test_can_write_k8s_executor_pod_spec_with_mismatched_workload_image_hash(
+    def test_can_write_k8s_executor_pod_spec_blocked_by_mismatched_workload_image_hash(
         self,
         application_context,
         application_state,
@@ -562,7 +833,9 @@ class TestAirflowCoordinatorRequires:
         )
 
         with application_context(
-            application_context.on.relation_changed(relation_mismatched_workload_image_hash),
+            application_context.on.relation_changed(
+                relation_mismatched_workload_image_hash
+            ),
             state_mismatched_airflow_versions,
         ) as manager:
             manager.run()
@@ -573,6 +846,27 @@ class TestAirflowCoordinatorRequires:
                 in application_context.juju_log
             )
 
+            assert not manager.charm.requirer.can_write_kubernetes_executor_pod_spec
+
+    def test_can_write_k8s_executor_pod_spec_blocked_when_container_not_connectable(
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
+        application_workload_container,
+    ):
+        container_not_ready = dataclasses.replace(
+            application_workload_container, can_connect=False
+        )
+        state = dataclasses.replace(application_state, containers=[container_not_ready])
+
+        with application_context(
+            application_context.on.relation_changed(
+                application_airflow_coordinator_relation
+            ),
+            state,
+        ) as manager:
+            manager.run()
             assert not manager.charm.requirer.can_write_kubernetes_executor_pod_spec
 
 
@@ -586,7 +880,9 @@ class TestAirflowCoordinatorProvides:
         state = generate_coordinator_state()
 
         with coordinator_context(
-            coordinator_context.on.relation_changed(state.get_relations("airflow-coordinator")[0]),
+            coordinator_context.on.relation_changed(
+                state.get_relations("airflow-coordinator")[0]
+            ),
             state,
         ) as manager:
             state_out = manager.run()
@@ -624,7 +920,9 @@ class TestAirflowCoordinatorProvides:
             manager.charm.provider.set_validation_errors()
 
             for relation in state_out.relations:
-                validation_failures = json.loads(relation.local_app_data["validation-failures"])
+                validation_failures = json.loads(
+                    relation.local_app_data["validation-failures"]
+                )
 
                 assert validation_failures == [
                     {
@@ -638,14 +936,22 @@ class TestAirflowCoordinatorProvides:
     ):
         missing_components = {
             failure["component"]
-            for failure in json.loads(missing_components_relation_data["validation-failures"])
+            for failure in json.loads(
+                missing_components_relation_data["validation-failures"]
+            )
         }
-        present_components = set(airflow_coordinator.AirflowCoreComponentEnum) - missing_components
+        present_components = (
+            set(airflow_coordinator.AirflowCoreComponentEnum) - missing_components
+        )
 
-        state = generate_coordinator_state({component: {} for component in present_components})
+        state = generate_coordinator_state(
+            {component: {} for component in present_components}
+        )
 
         with coordinator_context(
-            coordinator_context.on.relation_changed(state.get_relations("airflow-coordinator")[0]),
+            coordinator_context.on.relation_changed(
+                state.get_relations("airflow-coordinator")[0]
+            ),
             state,
         ) as manager:
             state_out = manager.run()
@@ -671,19 +977,25 @@ class TestAirflowCoordinatorProvides:
     ):
         invalid_components = {
             failure["component"]
-            for failure in json.loads(invalid_airflow_version_relation_data["validation-failures"])
+            for failure in json.loads(
+                invalid_airflow_version_relation_data["validation-failures"]
+            )
         }
 
         component_permutations = {
             component: {"airflow_version": "0.0.0"} for component in invalid_components
         }
-        for component in set(airflow_coordinator.AirflowCoreComponentEnum) - invalid_components:
+        for component in (
+            set(airflow_coordinator.AirflowCoreComponentEnum) - invalid_components
+        ):
             component_permutations[component] = {}
 
         state = generate_coordinator_state(component_permutations)
 
         with coordinator_context(
-            coordinator_context.on.relation_changed(state.get_relations("airflow-coordinator")[0]),
+            coordinator_context.on.relation_changed(
+                state.get_relations("airflow-coordinator")[0]
+            ),
             state,
         ) as manager:
             state_out = manager.run()
@@ -717,15 +1029,20 @@ class TestAirflowCoordinatorProvides:
         }
 
         component_permutations = {
-            component: {"workload_image_hash": "0.0.0"} for component in invalid_components
+            component: {"workload_image_hash": "0.0.0"}
+            for component in invalid_components
         }
-        for component in set(airflow_coordinator.AirflowCoreComponentEnum) - invalid_components:
+        for component in (
+            set(airflow_coordinator.AirflowCoreComponentEnum) - invalid_components
+        ):
             component_permutations[component] = {}
 
         state = generate_coordinator_state(component_permutations)
 
         with coordinator_context(
-            coordinator_context.on.relation_changed(state.get_relations("airflow-coordinator")[0]),
+            coordinator_context.on.relation_changed(
+                state.get_relations("airflow-coordinator")[0]
+            ),
             state,
         ) as manager:
             state_out = manager.run()
@@ -752,7 +1069,9 @@ class TestAirflowCoordinatorProvides:
         state = generate_coordinator_state()
 
         with coordinator_context(
-            coordinator_context.on.relation_changed(state.get_relations("airflow-coordinator")[0]),
+            coordinator_context.on.relation_changed(
+                state.get_relations("airflow-coordinator")[0]
+            ),
             state,
         ) as manager:
             airflow_config_params = {
@@ -763,7 +1082,10 @@ class TestAirflowCoordinatorProvides:
                 },
             }
 
-            assert manager.charm.provider.set_airflow_config(**airflow_config_params) is None
+            assert (
+                manager.charm.provider.set_airflow_config(**airflow_config_params)
+                is None
+            )
 
             state_out = manager.run()
             assert (
@@ -789,5 +1111,7 @@ class TestAirflowCoordinatorProvides:
                 assert secret_id is not None
 
                 assert state_out.get_secret(id=secret_id).latest_content == {
-                    "sensitive-data": json.dumps(airflow_config_params["sensitive_data"])
+                    "sensitive-data": json.dumps(
+                        airflow_config_params["sensitive_data"]
+                    )
                 }


### PR DESCRIPTION
## Description
This commit adds a new abstraction for enabling more generic configuration passing without the need of the requirer sending over its component name, container, etc. There are now two classes:
* AirflowCoordinatorCoreRequires - responsible for all the sharing, validation, and writing of the configuration on the Airflow core components (this is the previous behaviour)
* AirflowCoordinatorRequires - responsible for sharing and writing data, but with less validation, and with less strict requirements from the requirer. This becomes a parent class of AirflowCoordinatorCoreRequires.

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

NA

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->


This is the first PR on a series of multiple PRs to enable the Kubernetes Executor functionality and charm.

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
