### PR TITLE
feat: integrate with the executor interface

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -58,6 +58,8 @@ requires:
     limit: 1
   airflow-api-server:
     interface: airflow_api_server
+  airflow-executor-config:
+    interface: airflow_kubernetes_executor
     limit: 1
 
 peers:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -58,7 +58,7 @@ requires:
     limit: 1
   airflow-api-server:
     interface: airflow_api_server
-  airflow-executor-config:
+  airflow-kubernetes-executor-config:
     interface: airflow_kubernetes_executor
     limit: 1
 

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -265,10 +265,14 @@ SensitiveDataSecretStr = typing.Annotated[
 class AirflowCoordinatorProviderModel(data_interfaces.BaseCommonModel):
     """Provider side of the Airflow Coordinator model."""
 
-    config_template: str | None = pydantic.Field(default=None)
+    # FIXME: config_template accepts str | dict to support both Jinja2 templates
+    # (str from coordinator) and structured config dicts (from executor, deserialized
+    # by data_interfaces' get_data). This will change when we refactor the library
+    # to a much more generic one.
+    config_template: str | dict | None = pydantic.Field(default=None)
     kubernetes_executor_pod_spec: str | None = pydantic.Field(default=None)
     sensitive_data: SensitiveDataSecretStr = pydantic.Field(default=None)
-    secret_sensitive_data: data_interfaces.SecretString = pydantic.Field(default=None)
+    secret_sensitive_data: data_interfaces.SecretString | None = pydantic.Field(default=None)
 
     validation_failures: str | None = pydantic.Field(default=None)
 
@@ -543,7 +547,8 @@ class AirflowCoordinatorRequirerEventHandler(
             return self.interface.build_model(
                 self.relation.id, AirflowCoordinatorProviderModel, component=self.relation.app
             )
-        except pydantic.ValidationError:
+        except pydantic.ValidationError as e:
+            logger.error("VALIDATION ERROR: %s", e)
             return None
 
     @property
@@ -675,8 +680,7 @@ class AirflowCoordinatorProviderEventHandler(
                     if config_template:
                         model.config_template = config_template
 
-                    if kubernetes_executor_pod_spec:
-                        model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
+                    model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
 
                     if sensitive_data:
                         model.sensitive_data = json.dumps(sensitive_data)

--- a/src/charm.py
+++ b/src/charm.py
@@ -311,6 +311,9 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
                 self._run_db_migrate()
                 self._db_migration_ran = True
 
+            # We can decide which extra config we want to pass to the config_generator
+            # Right now we only have one extra, but in the future we can make decisions
+            # based on executors, providers, etc.
             self._config_provider.set_airflow_config(
                 self._config_generator.config_template_with_extra_config(
                     **self._config_generator.api_server_config,

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,6 +4,7 @@
 
 """The Airflow Coordinator charm application."""
 
+import json
 import logging
 
 import charms.airflow_api_server_k8s.v0.airflow_api_server as airflow_api_server
@@ -60,18 +61,26 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
             callback=self._reconcile,
         )
 
+        self._kubernetes_executor_requires = airflow_coordinator.AirflowCoordinatorRequires(
+            self,
+            constants.AIRFLOW_KUBERNETES_EXECUTOR_CONFIG_RELATION_NAME,
+            callback=self._reconcile,
+        )
+
         for event in [
             self.on.start,
+            self.on.config_changed,
             self.on.update_status,
             self.on[constants.WORKLOAD_CONTAINER_NAME].pebble_ready,
             self._database_requires.on.database_created,
             self._database_requires.on.endpoints_changed,
             self.on[constants.POSTGRES_RELATION_NAME].relation_broken,
+            self.on[constants.AIRFLOW_KUBERNETES_EXECUTOR_CONFIG_RELATION_NAME].relation_changed,
         ]:
             self.framework.observe(event, self._reconcile)
 
     @property
-    def _all_database_connection_details_present(self) -> None:
+    def _all_database_connection_details_present(self) -> bool:
         """Confirm if all database connection details present in postgres relation."""
         if not self._database_requires.relations:
             return False
@@ -141,13 +150,51 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
 
     def _required_dependencies_exist(self) -> bool:
         """Returns whether all required dependencies for the coordinator exist."""
-        # TODO: add k8s executor configurator relation here too
         return all(
             [
                 self.model.get_relation(constants.POSTGRES_RELATION_NAME),
                 self.model.get_relation(constants.AIRFLOW_API_SERVER_ENDPOINT_NAME),
             ]
         )
+
+    @property
+    def _kubernetes_executor_config(self) -> dict | None:
+        """Return the parsed executor config dict from the executor relation.
+
+        The executor stores its config as a JSON-serialised dict in the
+        ``config_template`` field of the relation databag.
+
+        Returns None when the executor relation is not established or
+        the executor has not yet shared its configuration.
+        """
+        if not self.model.get_relation(constants.AIRFLOW_KUBERNETES_EXECUTOR_CONFIG_RELATION_NAME):
+            return None
+        content = self._kubernetes_executor_requires.provider_content
+        if not content or not content.config_template:
+            logger.warning(constants.WAITING_FOR_KUBERNETES_EXECUTOR_CONFIG_MESSAGE)
+            return None
+        if isinstance(content.config_template, dict):
+            return content.config_template
+        try:
+            return json.loads(content.config_template)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning(constants.WAITING_FOR_KUBERNETES_EXECUTOR_CONFIG_MESSAGE)
+            return None
+
+    @property
+    def _kubernetes_executor_pod_spec(self) -> str | None:
+        """Return the rendered pod spec template from the K8s executor relation.
+
+        Returns None when the executor relation is not established or
+        the executor has not yet shared its pod spec.
+        """
+        if not self.model.get_relation(constants.AIRFLOW_KUBERNETES_EXECUTOR_CONFIG_RELATION_NAME):
+            return None
+        content = self._kubernetes_executor_requires.provider_content
+        if not content or not content.kubernetes_executor_pod_spec:
+            logger.warning(constants.WAITING_FOR_KUBERNETES_EXECUTOR_CONFIG_MESSAGE)
+            return None
+        return content.kubernetes_executor_pod_spec
 
     def _perform_checks(self) -> None:
         """Checks to ensure the charm is able to generate and distribute configs."""
@@ -228,8 +275,13 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
         airflow_coordinator.write_airflow_config(
             self._container,
             constants.AIRFLOW_CONFIG_PATH,
-            self._config_generator.config_template,
-            self._config_generator.sensitive_config_values,
+            self._config_generator.config_template_with_extra_config(
+                **self._config_generator.api_server_config,
+            ),
+            {
+                **self._config_generator.sensitive_config_values,
+                "render_sensitive_data": True,
+            },
             user=constants.WORKLOAD_USER,
             group=constants.WORKLOAD_GROUP,
         )
@@ -260,8 +312,15 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
                 self._db_migration_ran = True
 
             self._config_provider.set_airflow_config(
-                self._config_generator.config_template,
-                sensitive_data=self._config_generator.sensitive_config_values,
+                self._config_generator.config_template_with_extra_config(
+                    **self._config_generator.api_server_config,
+                    **(self._kubernetes_executor_config or {}),
+                ),
+                k8s_executor_pod_spec_template=self._kubernetes_executor_pod_spec,
+                sensitive_data={
+                    **self._config_generator.sensitive_config_values,
+                    "render_sensitive_data": True,
+                },
             )
         except ExceptionWithStatusError as e:
             logger.error(e)

--- a/src/config_generator.py
+++ b/src/config_generator.py
@@ -3,9 +3,10 @@
 
 """Charm support for the Airflow config generation."""
 
+import configparser
+import io
 import logging
 import pathlib
-import re
 
 import ops
 
@@ -47,63 +48,39 @@ class AirflowConfigGenerator:
 
         return f"postgresql+psycopg2://{username}:{password}@{endpoints[0]}/{database}"
 
-    @staticmethod
-    def _section_body(template: str, section: str) -> str | None:
-        """Return the text between a section header and the next header (or EOF)."""
-        match = re.search(
-            rf"^\[{re.escape(section)}\][^\S\n]*\n(.*?)(?=^\[|\Z)",
-            template,
-            re.MULTILINE | re.DOTALL,
-        )
-        return match.group(1) if match else None
-
     def config_template_with_extra_config(self, **extra_config) -> str:
-        """Return the Airflow config template merged with extra config from different integrators.
+        """Return the Airflow config template merged with extra config from different sources.
 
-        Existing keys are replaced with the integrator's value, new keys are
-        inserted under the existing section header, and entirely new sections
-        are appended.  This avoids ``DuplicateSectionError`` from ConfigParser
-        while allowing integrators to override defaults.
+        Uses configparser to parse and merge sections/keys, and ignores Jinja2
+        placeholders (via the RawConfigParser()).
+        Existing keys are overwritten, new keys are added to existing sections,
+        and entirely new sections are appended.
 
         Returns:
             Combined Jinja2 template string ready to share with core charms.
         """
-        # FIXME: this regex-based merge is fragile. A more elegant solution
-        # would be to use configparser or Jinja2 native solutions, which requires
-        # changes to the library and the core charms.
-        result = self.config_template
+        base_template = self.config_template
         if not extra_config:
-            return result
+            return base_template
 
-        new_sections = []
+        # NOTE: RawConfigParser treats Jinja2 condition-wrapped options
+        # (e.g. ``{% if x %}key = val{% endif %}``) as a single option whose
+        # name includes the Jinja2 prefix.  Overriding such an option via
+        # extra_config would add a *new* option instead of replacing it.
+        # This is acceptable today because no extra_config key conflicts with
+        # a condition-wrapped option in the template.
+        parser = configparser.RawConfigParser()
+        parser.read_string(base_template)
+
         for section, keys in extra_config.items():
-            body = self._section_body(result, section)
-            if body is not None:
-                existing_keys = set(re.findall(r"^(\w+)\s*=", body, re.MULTILINE))
-                new_key_lines = []
-                for k, v in keys.items():
-                    if k in existing_keys:
-                        result = re.sub(
-                            rf"^({re.escape(k)}\s*=\s*).*$",
-                            rf"\g<1>{v}",
-                            result,
-                            count=1,
-                            flags=re.MULTILINE,
-                        )
-                    else:
-                        new_key_lines.append(f"{k} = {v}")
-                if new_key_lines:
-                    key_lines = "\n".join(new_key_lines)
-                    pattern = rf"(\[{re.escape(section)}\][^\S\n]*\n)"
-                    result = re.sub(pattern, rf"\g<1>{key_lines}\n", result, count=1)
-            else:
-                key_lines = "\n".join(f"{k} = {v}" for k, v in keys.items())
-                new_sections.append(f"\n[{section}]\n{key_lines}")
+            if not parser.has_section(section):
+                parser.add_section(section)
+            for k, v in keys.items():
+                parser.set(section, k, v)
 
-        if new_sections:
-            result += "\n".join(new_sections) + "\n"
-
-        return result
+        output = io.StringIO()
+        parser.write(output)
+        return output.getvalue()
 
     @property
     def api_server_config(self) -> dict[str, dict[str, str]]:

--- a/src/config_generator.py
+++ b/src/config_generator.py
@@ -4,8 +4,9 @@
 """Charm support for the Airflow config generation."""
 
 import logging
+import pathlib
+import re
 
-import jinja2
 import ops
 
 logger = logging.getLogger(__name__)
@@ -19,20 +20,13 @@ class AirflowConfigGenerator:
 
     @property
     def config_template(self) -> str:
-        """The Airflow config template to pass to all related components."""
-        with open("src/templates/airflow_config.j2") as config_template_file:
-            config_template = config_template_file.read()
+        """The raw Airflow config Jinja2 template to pass to all related components.
 
-        return (
-            jinja2.Environment(loader=jinja2.BaseLoader(), undefined=jinja2.DebugUndefined)
-            .from_string(config_template)
-            .render(
-                {
-                    "api_server_base_url": f"http://{self._charm._api_server_requires.api_server_host}:{self._charm._api_server_requires.api_server_port}",
-                    "api_server_port": self._charm._api_server_requires.api_server_port,
-                }
-            )
-        )
+        Returns the template as-is, preserving all Jinja2 placeholders and
+        control-flow tags.  Downstream charms perform the final render with
+        the appropriate context (sensitive_config_values + extras).
+        """
+        return pathlib.Path("src/templates/airflow_config.j2").read_text()
 
     @property
     def _sql_alchemy_connection_string(self) -> str:
@@ -53,9 +47,85 @@ class AirflowConfigGenerator:
 
         return f"postgresql+psycopg2://{username}:{password}@{endpoints[0]}/{database}"
 
+    @staticmethod
+    def _section_body(template: str, section: str) -> str | None:
+        """Return the text between a section header and the next header (or EOF)."""
+        match = re.search(
+            rf"^\[{re.escape(section)}\][^\S\n]*\n(.*?)(?=^\[|\Z)",
+            template,
+            re.MULTILINE | re.DOTALL,
+        )
+        return match.group(1) if match else None
+
+    def config_template_with_extra_config(self, **extra_config) -> str:
+        """Return the Airflow config template merged with extra config from different integrators.
+
+        Existing keys are replaced with the integrator's value, new keys are
+        inserted under the existing section header, and entirely new sections
+        are appended.  This avoids ``DuplicateSectionError`` from ConfigParser
+        while allowing integrators to override defaults.
+
+        Returns:
+            Combined Jinja2 template string ready to share with core charms.
+        """
+        # FIXME: this regex-based merge is fragile. A more elegant solution
+        # would be to use configparser or Jinja2 native solutions, which requires
+        # changes to the library and the core charms.
+        result = self.config_template
+        if not extra_config:
+            return result
+
+        new_sections = []
+        for section, keys in extra_config.items():
+            body = self._section_body(result, section)
+            if body is not None:
+                existing_keys = set(re.findall(r"^(\w+)\s*=", body, re.MULTILINE))
+                new_key_lines = []
+                for k, v in keys.items():
+                    if k in existing_keys:
+                        result = re.sub(
+                            rf"^({re.escape(k)}\s*=\s*).*$",
+                            rf"\g<1>{v}",
+                            result,
+                            count=1,
+                            flags=re.MULTILINE,
+                        )
+                    else:
+                        new_key_lines.append(f"{k} = {v}")
+                if new_key_lines:
+                    key_lines = "\n".join(new_key_lines)
+                    pattern = rf"(\[{re.escape(section)}\][^\S\n]*\n)"
+                    result = re.sub(pattern, rf"\g<1>{key_lines}\n", result, count=1)
+            else:
+                key_lines = "\n".join(f"{k} = {v}" for k, v in keys.items())
+                new_sections.append(f"\n[{section}]\n{key_lines}")
+
+        if new_sections:
+            result += "\n".join(new_sections) + "\n"
+
+        return result
+
+    @property
+    def api_server_config(self) -> dict[str, dict[str, str]]:
+        """Return the API server config as extra config sections.
+
+        Uses the same {section: {key: value}} pattern as executor config.
+
+        FIXME: This config should be returned by the API server charm itself,
+        not generated here by the coordinator.
+        """
+        host = self._charm._api_server_requires.api_server_host
+        port = self._charm._api_server_requires.api_server_port
+        return {
+            "api": {
+                "base_url": f"http://{host}:{port}",
+                "port": str(port),
+            },
+        }
+
     @property
     def sensitive_config_values(self) -> dict[str, str]:
         """All sensitive values that will be included in the Airflow config template."""
         return {
-            "sql_alchemy_connection_string": self._sql_alchemy_connection_string,
+            "database__sql_alchemy_conn": self._sql_alchemy_connection_string,
         }

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,6 +5,7 @@
 
 AIRFLOW_COORDINATOR_RELATION_NAME = "airflow-coordinator"
 AIRFLOW_API_SERVER_ENDPOINT_NAME = "airflow-api-server"
+AIRFLOW_KUBERNETES_EXECUTOR_CONFIG_RELATION_NAME = "airflow-executor-config"
 
 PEER_RELATION_NAME = "coordinator-peers"
 
@@ -28,3 +29,6 @@ WAITING_FOR_API_SERVER_HOST_PORT_MESSAGE = "Waiting for host+port information fr
 MISMATCHED_AIRFLOW_VERSIONS_MESSAGE = "Integrated apps with mismatched airflow versions"
 MISMATCHED_WORKLOAD_IMAGE_HASHES_MESSAGE = "Integrated apps with mismatched workload image hashes"
 MISSING_INTEGRATIONS_MESSAGE_TEMPLATE = "Missing integrations with: {missing_core_components}"
+WAITING_FOR_KUBERNETES_EXECUTOR_CONFIG_MESSAGE = (
+    "Waiting for configuration from the kubernetes executor charm"
+)

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,7 +5,7 @@
 
 AIRFLOW_COORDINATOR_RELATION_NAME = "airflow-coordinator"
 AIRFLOW_API_SERVER_ENDPOINT_NAME = "airflow-api-server"
-AIRFLOW_KUBERNETES_EXECUTOR_CONFIG_RELATION_NAME = "airflow-executor-config"
+AIRFLOW_KUBERNETES_EXECUTOR_CONFIG_RELATION_NAME = "airflow-kubernetes-executor-config"
 
 PEER_RELATION_NAME = "coordinator-peers"
 

--- a/src/templates/airflow_config.j2
+++ b/src/templates/airflow_config.j2
@@ -1,10 +1,9 @@
 [core]
-executor = LocalExecutor
+executor = {{ executor | default('LocalExecutor') }}
 load_examples = False
 
 [database]
-sql_alchemy_conn = {{ sql_alchemy_connection_string }}
+{%- if render_sensitive_data %}
+sql_alchemy_conn = {{ database__sql_alchemy_conn }}
+{%- endif %}
 
-[api]
-base_url = {{ api_server_base_url }}
-port = {{ api_server_port }}

--- a/src/templates/airflow_config.j2
+++ b/src/templates/airflow_config.j2
@@ -3,7 +3,5 @@ executor = {{ executor | default('LocalExecutor') }}
 load_examples = False
 
 [database]
-{%- if render_sensitive_data %}
-sql_alchemy_conn = {{ database__sql_alchemy_conn }}
-{%- endif %}
+{% if render_sensitive_data %}sql_alchemy_conn = {{ database__sql_alchemy_conn }}{% endif %}
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -146,7 +146,7 @@ def test_relate_and_config_validation(juju: jubilant.Juju):
     )
     assert (
         "postgresql+psycopg2://"
-        in json.loads(all_sensitive_data[0])["sql_alchemy_connection_string"]
+        in json.loads(all_sensitive_data[0])["database__sql_alchemy_conn"]
     )
 
 
@@ -223,7 +223,7 @@ def test_remove_and_recreate_integrations(juju: jubilant.Juju):
 
     assert (
         "postgresql+psycopg2://"
-        in json.loads(all_sensitive_data[0])["sql_alchemy_connection_string"]
+        in json.loads(all_sensitive_data[0])["database__sql_alchemy_conn"]
     )
 
 
@@ -302,7 +302,7 @@ def test_remove_and_recreate_limited_integrations(juju: jubilant.Juju):
 
     assert (
         "postgresql+psycopg2://"
-        in json.loads(all_sensitive_data[0])["sql_alchemy_connection_string"]
+        in json.loads(all_sensitive_data[0])["database__sql_alchemy_conn"]
     )
 
 
@@ -358,5 +358,5 @@ def test_break_and_recreate_postgres_relation(juju: jubilant.Juju):
 
     assert (
         "postgresql+psycopg2://"
-        in json.loads(all_sensitive_data[0])["sql_alchemy_connection_string"]
+        in json.loads(all_sensitive_data[0])["database__sql_alchemy_conn"]
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -129,6 +129,28 @@ def airflow_api_server_requires_relation():
     )
 
 
+MOCK_KUBERNETES_EXECUTOR_CONFIG = {
+    "core": {
+        "executor": "KubernetesExecutor",
+    },
+    "kubernetes_executor": {
+        "namespace": "airflow-ns",
+        "pod_template_file": "/opt/airflow/pod_templates/worker_pod_template.yaml",
+        "base_image": "airflow:latest",
+    },
+}
+
+MOCK_KUBERNETES_EXECUTOR_POD_SPEC = "apiVersion: v1\nkind: Pod\nmetadata:\n  name: worker"
+
+
+@pytest.fixture(scope="function")
+def kubernetes_executor_config_relation_empty():
+    return ops.testing.Relation(
+        constants.AIRFLOW_KUBERNETES_EXECUTOR_CONFIG_RELATION_NAME,
+        remote_app_data={},
+    )
+
+
 @pytest.fixture(scope="function")
 def all_required_relations(
     postgres_relation,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -288,7 +288,7 @@ def test_db_migration_does_not_run_on_state_true(
     with unittest.mock.patch(
         "config_generator.AirflowConfigGenerator.config_template",
         new_callable=unittest.mock.PropertyMock(
-            return_value="mock_config: {{ sql_alchemy_connection_string }}"
+            return_value="[core]\nexecutor = {{ executor | default('LocalExecutor') }}\n"
         ),
     ):
         state_in = ops.testing.State(
@@ -317,7 +317,7 @@ def test_db_migration_runs_on_state_false(
     with unittest.mock.patch(
         "config_generator.AirflowConfigGenerator.config_template",
         new_callable=unittest.mock.PropertyMock(
-            return_value="mock_config: {{ sql_alchemy_connection_string }}"
+            return_value="[core]\nexecutor = {{ executor | default('LocalExecutor') }}\n"
         ),
     ):
         state_in = ops.testing.State(
@@ -342,7 +342,7 @@ def test_db_migration_failure(context, state, mock_command_executor, workload_co
     with unittest.mock.patch(
         "config_generator.AirflowConfigGenerator.config_template",
         new_callable=unittest.mock.PropertyMock(
-            return_value="mock_config: {{ sql_alchemy_connection_string }}"
+            return_value="[core]\nexecutor = {{ executor | default('LocalExecutor') }}\n"
         ),
     ):
         state_out = context.run(context.on.pebble_ready(workload_container), state)
@@ -390,7 +390,7 @@ class TestKubernetesExecutorConfig:
         with unittest.mock.patch(
             "config_generator.AirflowConfigGenerator.config_template",
             new_callable=unittest.mock.PropertyMock(
-                return_value="mock_config: {{ sql_alchemy_connection_string }}"
+                return_value="[core]\nexecutor = {{ executor | default('LocalExecutor') }}\n"
             ),
         ), unittest.mock.patch.object(
             AirflowCoordinatorK8SOperatorCharm, "_kubernetes_executor_config",
@@ -413,7 +413,7 @@ class TestKubernetesExecutorConfig:
         with unittest.mock.patch(
             "config_generator.AirflowConfigGenerator.config_template",
             new_callable=unittest.mock.PropertyMock(
-                return_value="mock_config: {{ sql_alchemy_connection_string }}"
+                return_value="[core]\nexecutor = {{ executor | default('LocalExecutor') }}\n"
             ),
         ), unittest.mock.patch.object(
             AirflowCoordinatorK8SOperatorCharm, "_kubernetes_executor_config",
@@ -440,7 +440,7 @@ class TestKubernetesExecutorConfig:
         with unittest.mock.patch(
             "config_generator.AirflowConfigGenerator.config_template",
             new_callable=unittest.mock.PropertyMock(
-                return_value="mock_config: {{ sql_alchemy_connection_string }}"
+                return_value="[core]\nexecutor = {{ executor | default('LocalExecutor') }}\n"
             ),
         ), unittest.mock.patch.object(
             AirflowCoordinatorK8SOperatorCharm, "_kubernetes_executor_config",
@@ -466,7 +466,7 @@ class TestKubernetesExecutorConfig:
         with unittest.mock.patch(
             "config_generator.AirflowConfigGenerator.config_template",
             new_callable=unittest.mock.PropertyMock(
-                return_value="mock_config: {{ sql_alchemy_connection_string }}"
+                return_value="[core]\nexecutor = {{ executor | default('LocalExecutor') }}\n"
             ),
         ):
             state_out = context.run(context.on.start(), state)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -10,9 +10,11 @@ import unittest.mock
 import charms.airflow_coordinator_k8s.v0.airflow_coordinator as airflow_coordinator
 import ops
 import ops.testing
+from conftest import MOCK_KUBERNETES_EXECUTOR_CONFIG, MOCK_KUBERNETES_EXECUTOR_POD_SPEC
 
 import command_executor
 import constants
+from charm import AirflowCoordinatorK8SOperatorCharm
 
 
 def test_non_leader_unit(context, state, mock_command_executor):
@@ -350,6 +352,128 @@ def test_db_migration_failure(context, state, mock_command_executor, workload_co
     # Verify that config was not distributed to core charms
     for relation in state_out.get_relations("airflow-coordinator"):
         assert "config-template" not in relation.local_app_data
+
+
+class TestKubernetesExecutorConfig:
+    def test_kubernetes_executor_config_returns_none_without_relation(
+        self, context, state, mock_command_executor
+    ):
+        """Verify _kubernetes_executor_config returns None when relation is absent."""
+        with context(context.on.start(), state) as manager:
+            charm = manager.charm
+            assert charm._kubernetes_executor_config is None
+
+    def test_kubernetes_executor_config_returns_none_when_relation_empty(
+        self,
+        context,
+        all_required_relations,
+        kubernetes_executor_config_relation_empty,
+        workload_container,
+        mock_command_executor,
+    ):
+        """Verify _kubernetes_executor_config returns None when relation has no data yet."""
+        all_required_relations.append(kubernetes_executor_config_relation_empty)
+        state = ops.testing.State(
+            leader=True,
+            containers=[workload_container],
+            relations=all_required_relations,
+        )
+
+        with context(context.on.start(), state) as manager:
+            charm = manager.charm
+            assert charm._kubernetes_executor_config is None
+
+    def test_kubernetes_executor_config_merges_into_distributed_template(
+        self, context, state, mock_command_executor
+    ):
+        """Verify executor config sections are merged into the distributed config template."""
+        with unittest.mock.patch(
+            "config_generator.AirflowConfigGenerator.config_template",
+            new_callable=unittest.mock.PropertyMock(
+                return_value="mock_config: {{ sql_alchemy_connection_string }}"
+            ),
+        ), unittest.mock.patch.object(
+            AirflowCoordinatorK8SOperatorCharm, "_kubernetes_executor_config",
+            new_callable=unittest.mock.PropertyMock(return_value=MOCK_KUBERNETES_EXECUTOR_CONFIG),
+        ):
+            state_out = context.run(context.on.start(), state)
+
+        assert state_out.unit_status == ops.ActiveStatus()
+
+        for relation in state_out.get_relations("airflow-coordinator"):
+            config_template = relation.local_app_data.get("config-template", "")
+            assert "[kubernetes_executor]" in config_template
+            assert "namespace = airflow-ns" in config_template
+            assert "base_image = airflow:latest" in config_template
+
+    def test_kubernetes_executor_config_sets_executor_in_core_section(
+        self, context, state, mock_command_executor
+    ):
+        """Verify KubernetesExecutor is merged into the [core] section."""
+        with unittest.mock.patch(
+            "config_generator.AirflowConfigGenerator.config_template",
+            new_callable=unittest.mock.PropertyMock(
+                return_value="mock_config: {{ sql_alchemy_connection_string }}"
+            ),
+        ), unittest.mock.patch.object(
+            AirflowCoordinatorK8SOperatorCharm, "_kubernetes_executor_config",
+            new_callable=unittest.mock.PropertyMock(return_value=MOCK_KUBERNETES_EXECUTOR_CONFIG),
+        ):
+            state_out = context.run(context.on.start(), state)
+
+        for relation in state_out.get_relations("airflow-coordinator"):
+            config_template = relation.local_app_data.get("config-template", "")
+            assert "executor = KubernetesExecutor" in config_template
+
+    def test_kubernetes_executor_pod_spec_returns_none_without_relation(
+        self, context, state, mock_command_executor
+    ):
+        """Verify _kubernetes_executor_pod_spec returns None when relation is absent."""
+        with context(context.on.start(), state) as manager:
+            charm = manager.charm
+            assert charm._kubernetes_executor_pod_spec is None
+
+    def test_kubernetes_executor_pod_spec_distributed_to_core_charms(
+        self, context, state, mock_command_executor
+    ):
+        """Verify the pod spec template is distributed to core charms."""
+        with unittest.mock.patch(
+            "config_generator.AirflowConfigGenerator.config_template",
+            new_callable=unittest.mock.PropertyMock(
+                return_value="mock_config: {{ sql_alchemy_connection_string }}"
+            ),
+        ), unittest.mock.patch.object(
+            AirflowCoordinatorK8SOperatorCharm, "_kubernetes_executor_config",
+            new_callable=unittest.mock.PropertyMock(return_value=MOCK_KUBERNETES_EXECUTOR_CONFIG),
+        ), unittest.mock.patch.object(
+            AirflowCoordinatorK8SOperatorCharm, "_kubernetes_executor_pod_spec",
+            new_callable=unittest.mock.PropertyMock(
+                return_value=MOCK_KUBERNETES_EXECUTOR_POD_SPEC
+            ),
+        ):
+            state_out = context.run(context.on.start(), state)
+
+        for relation in state_out.get_relations("airflow-coordinator"):
+            assert (
+                relation.local_app_data.get("kubernetes-executor-pod-spec")
+                == MOCK_KUBERNETES_EXECUTOR_POD_SPEC
+            )
+
+    def test_default_executor_is_local_without_kubernetes_executor_relation(
+        self, context, state, mock_command_executor
+    ):
+        """Verify executor defaults to LocalExecutor when no executor relation exists."""
+        with unittest.mock.patch(
+            "config_generator.AirflowConfigGenerator.config_template",
+            new_callable=unittest.mock.PropertyMock(
+                return_value="mock_config: {{ sql_alchemy_connection_string }}"
+            ),
+        ):
+            state_out = context.run(context.on.start(), state)
+
+        for relation in state_out.get_relations("airflow-coordinator"):
+            config_template = relation.local_app_data.get("config-template", "")
+            assert "executor = KubernetesExecutor" not in config_template
 
 
 class TestPebbleLayer:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,6 +3,7 @@
 #
 # To learn more about testing, see https://documentation.ubuntu.com/ops/latest/explanation/testing/
 
+import configparser
 import dataclasses
 import json
 import unittest.mock
@@ -402,28 +403,11 @@ class TestKubernetesExecutorConfig:
 
         for relation in state_out.get_relations("airflow-coordinator"):
             config_template = relation.local_app_data.get("config-template", "")
-            assert "[kubernetes_executor]" in config_template
-            assert "namespace = airflow-ns" in config_template
-            assert "base_image = airflow:latest" in config_template
-
-    def test_kubernetes_executor_config_sets_executor_in_core_section(
-        self, context, state, mock_command_executor
-    ):
-        """Verify KubernetesExecutor is merged into the [core] section."""
-        with unittest.mock.patch(
-            "config_generator.AirflowConfigGenerator.config_template",
-            new_callable=unittest.mock.PropertyMock(
-                return_value="[core]\nexecutor = {{ executor | default('LocalExecutor') }}\n"
-            ),
-        ), unittest.mock.patch.object(
-            AirflowCoordinatorK8SOperatorCharm, "_kubernetes_executor_config",
-            new_callable=unittest.mock.PropertyMock(return_value=MOCK_KUBERNETES_EXECUTOR_CONFIG),
-        ):
-            state_out = context.run(context.on.start(), state)
-
-        for relation in state_out.get_relations("airflow-coordinator"):
-            config_template = relation.local_app_data.get("config-template", "")
-            assert "executor = KubernetesExecutor" in config_template
+            parsed = configparser.ConfigParser()
+            parsed.read_string(config_template)
+            assert parsed["core"]["executor"] == "KubernetesExecutor"
+            assert parsed["kubernetes_executor"]["namespace"] == "airflow-ns"
+            assert parsed["kubernetes_executor"]["base_image"] == "airflow:latest"
 
     def test_kubernetes_executor_pod_spec_returns_none_without_relation(
         self, context, state, mock_command_executor


### PR DESCRIPTION
## Description
Integrate the coordinator with the Kubernetes executor charm via the airflow-executor-config relation,
enabling dynamic executor configuration and pod spec distribution to core Airflow charms.

Key changes:
- Add airflow-executor-config relation endpoint to receive executor configuration
- Refactor config template to return raw Jinja2 (no pre-rendering), with API server and executor
values merged as structured {section: {key: value}} extra config via config_template_with_extra_config
- Config merge that replaces existing keys, inserts new keys under existing sections, and appends new sections using configparser
- Distribute the executor's pod spec template (kubernetes-executor-pod-spec) to core charms
- Rename sensitive config key from sql_alchemy_connection_string to database__sql_alchemy_conn to match Airflow's <section>__<key> convention

Library changes (airflow_coordinator v0, LIBPATCH 4 -> 5):
- Widen config_template type to str | dict | None to handle get_data()'s automatic JSON
deserialization of structured config from the executor
- Make secret_sensitive_data type SecretString | None so validation doesn't fail when the executor
relation doesn't provide secrets
- Remove truthiness guard on kubernetes_executor_pod_spec in update_content so None clears stale pod
specs after relation removal
- Log ValidationError in provider_content instead of silently swallowing it

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

1. charmcraft pack the coordinator                                                                    
2. Deploy with postgresql-k8s, airflow api server, scheduler, triggerer, and the Kubernetes executor charm from https://github.com/canonical/airflow-kubernetes-executor-k8s-operator/pull/2
3. Integrate coordinator and executor through airflow-coordinator and airflow-executor-config relations. 
4. Check that core charms are receiving k8s executor config in their airflow.cfg `kubectl exec -ti -nairflow scheduler-0 -c airflow-scheduler -- cat /opt/airflow/airflow.cfg`
5. Check relation data bag for k8s pod spec (juju show-unit coordinator should suffice)                                                             
6. Remove the executor integration: verify the coordinator falls back to LocalExecutor and clears the pod spec from core charm databags                                                                    
7. Re-add the executor integration: verify KubernetesExecutor config is restored 

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [x] Integration tests added or updated
- [ ] Documentation updated
