### PR TITLE
[WF-318] Remove redundant providers.tf

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,2 +1,0 @@
-# CC008: include explicit provider block for a consistent module layout.
-provider "juju" {}


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
This PR removes the redundant provider block that's empty helping avoid warnings while compiling the solution module.
`provider.tf` is designed to accomodate provider configuration such as credentials, region etc. At this point of time, these are not necessary and hence we had empty provider block earlier. 
To avoid seeing those warnings on having empty provider block, this PR aims to remove it.
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
