### PR TITLE
Fix typo in the key name used to access raw contents of the databag

### DIFF
--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -121,7 +121,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 # TODO: add your code here! Happy coding!
 
@@ -397,7 +397,7 @@ class AirflowCoordinatorRequirerEventHandler(
         if (
             "config-template" in _diff.changed
             or "kubernetes-executor-pod-spec" in _diff.changed
-            or "sensitive_data" in _diff.changed
+            or "sensitive-data" in _diff.changed
         ):
             getattr(self.on, "airflow_config_updated").emit(
                 event.relation, app=event.app, unit=event.unit, content=content


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
When accessing raw contents of the relation databag, underscores were used instead of hyphens for the keys. This PR corrects this mistake

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
