### PR TITLE
Add docstring further describing details of how TLS CA chains are written to workload containers

### DIFF
--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -165,7 +165,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 7
 
 
 logger = logging.getLogger(__name__)
@@ -1020,7 +1020,16 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         )
 
     def write_tls_ca_chains(self, user: str, group: str) -> None:
-        """Write available TLS CA chains to the workload container."""
+        """Write available TLS CA chains to the workload container.
+
+        The TLS CA chains are written to a preset filepath (based on the
+        filepath encoded in the Airflow connection). This filepath is included
+        in the information retrieved from the relation databag.
+
+        This method only writes contents to the workload container if there is
+        a difference between existing file contents and file contents specified
+        in the relation databag.
+        """
         provider_content = self._requirer_handler.provider_content
 
         for filename, tls_ca_chain in provider_content.tls_ca_chains.items():


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
As a follow up of https://github.com/canonical/airflow-core-operators/pull/35, this PR adds a docstring that was missed in PR #32. The docstring further elaborates the nuances of how the `AirflowCoordinatorCoreRequires.write_tls_ca_chains()`

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
