### PR TITLE
[WF-401] set up to support ssh passphrase and ssh port

### DIFF
--- a/lib/charms/git_integrator/v0/git.py
+++ b/lib/charms/git_integrator/v0/git.py
@@ -92,7 +92,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +118,12 @@ SSHPrivateKeyStr = typing.Annotated[
     "ssh-private-key",
 ]
 
+SSHPassphraseStr = typing.Annotated[
+    data_interfaces.OptionalSecretStr,
+    pydantic.Field(default=None, exclude=True),
+    "ssh-passphrase",
+]
+
 
 class GitProviderModel(data_interfaces.BaseCommonModel):
     """Provider side of the git relation interface."""
@@ -140,7 +146,12 @@ class GitProviderModel(data_interfaces.BaseCommonModel):
     secret_ssh_private_key: data_interfaces.SecretString | None = pydantic.Field(
         default=None, tag="restricted"
     )
+    ssh_passphrase: SSHPassphraseStr
+    secret_ssh_passphrase: data_interfaces.SecretString | None = pydantic.Field(
+        default=None, tag="restricted"
+    )
     ssh_strict_host_key_checking: bool | None = pydantic.Field(default=None, tag="resettable")
+    ssh_port: int | None = pydantic.Field(default=None, tag="resettable")
 
     # hack to enable databag diff computation with data_interfaces v1 charm lib
     request_id: str = pydantic.Field(default="fixed_request_id", exclude=True, tag="restricted")
@@ -423,7 +434,11 @@ class GitProviderEventHandler(data_interfaces.EventHandlers, typing.Generic[TGit
                         if model.secret_ssh_private_key:
                             model.ssh_private_key = "None"
 
+                        if model.secret_ssh_passphrase:
+                            model.ssh_passphrase = "None"
+
                         model.ssh_strict_host_key_checking = None
+                        model.ssh_port = None
 
                     if (
                         not authentication_method
@@ -540,7 +555,9 @@ class GitProvides(ops.Object):
                 - credentials_username (if authentication_method == "credentials")
                 - credentials_personal_access_token (if authentication_method == "credentials")
                 - ssh_private_key (if authentication_method == "ssh")
+                - ssh_passphrase (optional if authentication_method == "ssh")
                 - ssh_strict_host_key_checking (optional if authentication_method == "ssh")
+                - ssh_port (optional if authentication_method == "ssh")
         """
         if not self.relations_exists:
             return
@@ -552,7 +569,12 @@ class GitProvides(ops.Object):
             raise ValueError("Prohibited fields in provided connection info")
 
         credentials_fields = ["credentials_username", "credentials_personal_access_token"]
-        ssh_fields = ["ssh_private_key", "ssh_strict_host_key_checking"]
+        ssh_fields = [
+            "ssh_private_key",
+            "ssh_passphrase",
+            "ssh_strict_host_key_checking",
+            "ssh_port",
+        ]
 
         if connection_info.get("authentication_method") == AuthenticationMethodEnum.CREDENTIALS:
             if not all(key in connection_info for key in credentials_fields):

--- a/src/command_executor.py
+++ b/src/command_executor.py
@@ -207,10 +207,16 @@ class CommandExecutor:
         if git_provider_model.authentication_method == git.AuthenticationMethodEnum.SSH:
             extras["private_key"] = git_provider_model.ssh_private_key
 
+            if git_provider_model.ssh_passphrase is not None:
+                extras["private_key_passphrase"] = git_provider_model.ssh_passphrase
+
             if git_provider_model.ssh_strict_host_key_checking is not None:
                 extras["strict_host_key_checking"] = (
                     git_provider_model.ssh_strict_host_key_checking
                 )
+
+            if git_provider_model.ssh_port is not None:
+                extras["ssh_port"] = str(git_provider_model.ssh_port)
 
         extras_options = ["--conn-extra", json.dumps(extras)] if extras else []
 

--- a/src/connection_manager.py
+++ b/src/connection_manager.py
@@ -218,8 +218,12 @@ class AirflowConnectionManager:
                 or airflow_connection.password
                 or airflow_connection.extra_dejson.get("private_key")
                 != git_provider_model.ssh_private_key
+                or airflow_connection.extra_dejson.get("private_key_passphrase")
+                != git_provider_model.ssh_passphrase
                 or json.loads(airflow_connection.extra_dejson.get("strict_host_key_checking"))
                 != git_provider_model.ssh_strict_host_key_checking
+                or airflow_connection.extra_dejson.get("ssh_port")
+                != (str(git_provider_model.ssh_port) if git_provider_model.ssh_port else None)
             )
         else:
             has_authentication_changed = False

--- a/src/connection_manager.py
+++ b/src/connection_manager.py
@@ -206,6 +206,8 @@ class AirflowConnectionManager:
             has_authentication_changed = (
                 airflow_connection.extra_dejson.get("private_key")
                 or airflow_connection.extra_dejson.get("strict_host_key_checking")
+                or airflow_connection.extra_dejson.get("private_key_passphrase")
+                or airflow_connection.extra_dejson.get("ssh_port")
                 or airflow_connection.login != git_provider_model.credentials_username
                 or airflow_connection.password
                 != git_provider_model.credentials_personal_access_token

--- a/tests/unit/test_command_executor.py
+++ b/tests/unit/test_command_executor.py
@@ -311,3 +311,58 @@ class TestCommandExecutor:
                 "AIRFLOW_HOME": constants.AIRFLOW_HOME,
             },
         )
+
+    def test_add_airflow_git_ssh_connection_with_passphrase_and_port(
+        self, executor, mock_container
+    ):
+        mock_process = unittest.mock.MagicMock()
+        mock_process.wait_output.return_value = ("Airflow connection added", "")
+        mock_container.exec.return_value = mock_process
+
+        git_provider_model_ssh = git.GitProviderModel(
+            repository_url="test-repo-url",
+            path="test/path/",
+            tracking_ref="test-tracking-ref",
+            authentication_method=git.AuthenticationMethodEnum.SSH,
+            ssh_private_key="test-private-key",
+            ssh_passphrase="test-passphrase",
+            ssh_strict_host_key_checking=True,
+            ssh_port=2222,
+        )
+
+        result = executor.add_airflow_git_connection(
+            "test-connection-id",
+            git_provider_model_ssh,
+        )
+
+        assert result.success is True
+        assert result.stdout == "Airflow connection added"
+        assert result.stderr == ""
+        assert result.return_code == 0
+
+        mock_container.exec.assert_called_once_with(
+            [
+                "airflow",
+                "connections",
+                "add",
+                "test-connection-id",
+                "--conn-type",
+                "git",
+                "--conn-host",
+                "test-repo-url",
+                "--conn-extra",
+                json.dumps(
+                    {
+                        "private_key": "test-private-key",
+                        "private_key_passphrase": "test-passphrase",
+                        "strict_host_key_checking": True,
+                        "ssh_port": "2222",
+                    },
+                ),
+            ],
+            user=constants.WORKLOAD_USER,
+            group=constants.WORKLOAD_GROUP,
+            environment={
+                "AIRFLOW_HOME": constants.AIRFLOW_HOME,
+            },
+        )

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -104,6 +104,18 @@ def valid_git_provider_model():
 
 
 @pytest.fixture(scope="function")
+def valid_git_ssh_provider_model():
+    return git.GitProviderModel(
+        repository_url="test-repo-url",
+        authentication_method=git.AuthenticationMethodEnum.SSH,
+        ssh_private_key="test-private-key",
+        ssh_passphrase="test-passphrase",
+        ssh_strict_host_key_checking=True,
+        ssh_port=2222,
+    )
+
+
+@pytest.fixture(scope="function")
 def airflow_connection_for_valid_git_provider_model():
     return connection_manager.AirflowConnection(
         conn_id="git_relation_2_connection",
@@ -277,6 +289,78 @@ class TestConnectionManager:
 
         assert airflow_connection_manager.has_connection_for_git_changed(
             "git_relation_2_connection", valid_git_provider_model
+        )
+
+    def test_has_connection_for_git_ssh_with_changed_passphrase(
+        self,
+        airflow_connection_manager,
+        valid_git_ssh_provider_model,
+        mock_command_executor,
+    ):
+        """Test change detection when SSH passphrase changes."""
+        mock_command_executor[
+            "list_airflow_connections"
+        ].return_value = command_executor_with_json_result(
+            [
+                {
+                    "conn_id": "git_relation_3_connection",
+                    "conn_type": "git",
+                    "host": "test-repo-url",
+                    "extra-dejson": {
+                        "private_key": "test-private-key",
+                        "private_key_passphrase": "test-passphrase",
+                        "strict_host_key_checking": "true",
+                        "ssh_port": "2222",
+                    },
+                },
+            ]
+        )
+
+        assert not airflow_connection_manager.has_connection_for_git_changed(
+            "git_relation_3_connection", valid_git_ssh_provider_model
+        )
+
+        valid_git_ssh_provider_model.ssh_passphrase = "new-passphrase"
+
+        airflow_connection_manager.refresh()
+        assert airflow_connection_manager.has_connection_for_git_changed(
+            "git_relation_3_connection", valid_git_ssh_provider_model
+        )
+
+    def test_has_connection_for_git_ssh_with_changed_port(
+        self,
+        airflow_connection_manager,
+        valid_git_ssh_provider_model,
+        mock_command_executor,
+    ):
+        """Test change detection when SSH port changes."""
+        mock_command_executor[
+            "list_airflow_connections"
+        ].return_value = command_executor_with_json_result(
+            [
+                {
+                    "conn_id": "git_relation_3_connection",
+                    "conn_type": "git",
+                    "host": "test-repo-url",
+                    "extra-dejson": {
+                        "private_key": "test-private-key",
+                        "private_key_passphrase": "test-passphrase",
+                        "strict_host_key_checking": "true",
+                        "ssh_port": "2222",
+                    },
+                },
+            ]
+        )
+
+        assert not airflow_connection_manager.has_connection_for_git_changed(
+            "git_relation_3_connection", valid_git_ssh_provider_model
+        )
+
+        valid_git_ssh_provider_model.ssh_port = 3333
+
+        airflow_connection_manager.refresh()
+        assert airflow_connection_manager.has_connection_for_git_changed(
+            "git_relation_3_connection", valid_git_ssh_provider_model
         )
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -309,8 +309,6 @@ class TestConnectionManager:
                     "extra-dejson": {
                         "private_key": "old-key",
                         "private_key_passphrase": "old-passphrase",
-                        "strict_host_key_checking": "true",
-                        "ssh_port": "2222",
                     },
                 },
             ]

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -291,6 +291,63 @@ class TestConnectionManager:
             "git_relation_2_connection", valid_git_provider_model
         )
 
+    def test_has_connection_for_git_credentials_detects_leftover_ssh_passphrase(
+        self,
+        airflow_connection_manager,
+        valid_git_provider_model,
+        mock_command_executor,
+    ):
+        """Test that switching from SSH to credentials detects leftover private_key_passphrase."""
+        mock_command_executor[
+            "list_airflow_connections"
+        ].return_value = command_executor_with_json_result(
+            [
+                {
+                    "conn_id": "git_relation_2_connection",
+                    "conn_type": "git",
+                    "host": "test-repo-url",
+                    "extra-dejson": {
+                        "private_key": "old-key",
+                        "private_key_passphrase": "old-passphrase",
+                        "strict_host_key_checking": "true",
+                        "ssh_port": "2222",
+                    },
+                },
+            ]
+        )
+
+        assert airflow_connection_manager.has_connection_for_git_changed(
+            "git_relation_2_connection", valid_git_provider_model
+        )
+
+    def test_has_connection_for_git_credentials_detects_leftover_ssh_port(
+        self,
+        airflow_connection_manager,
+        valid_git_provider_model,
+        mock_command_executor,
+    ):
+        """Test that switching from SSH to credentials detects leftover ssh_port."""
+        mock_command_executor[
+            "list_airflow_connections"
+        ].return_value = command_executor_with_json_result(
+            [
+                {
+                    "conn_id": "git_relation_2_connection",
+                    "conn_type": "git",
+                    "host": "test-repo-url",
+                    "login": "test-login",
+                    "password": "test-personal-access-token",
+                    "extra-dejson": {
+                        "ssh_port": "2222",
+                    },
+                },
+            ]
+        )
+
+        assert airflow_connection_manager.has_connection_for_git_changed(
+            "git_relation_2_connection", valid_git_provider_model
+        )
+
     def test_has_connection_for_git_ssh_with_changed_passphrase(
         self,
         airflow_connection_manager,


### PR DESCRIPTION
## Description

Updates the coordinator charm to consume the new SSH passphrase and SSH port fields introduced in the git-integrator charm lib (`LIBPATCH 3`).

- Synced `lib/charms/git_integrator/v0/git.py` to `LIBPATCH 3` (adds `ssh_passphrase` and `ssh_port` fields to `GitProviderModel`)
- `add_airflow_git_connection` in `command_executor.py` now includes `private_key_passphrase` and `ssh_port` in the Airflow connection extras JSON when they are set on the provider model
- `has_connection_for_git_changed` in `connection_manager.py` now detects changes to passphrase and port, triggering a connection update when either field changes

Both fields are optional — existing git integrations without a passphrase or custom port continue to work without any change.

---
## Testing instructions

1. Deploy Charmed Airflow with a git-integrator integration using SSH authentication
2. Configure git-integrator with a passphrase and custom port (see git-integrator PR for steps)
3. Verify the Airflow connection contains the new fields:
```
juju ssh airflow-coordinator-k8s/0 --
airflow connections list --output json
```
Expected: `"private_key_passphrase"` and `"ssh_port"` present in the connection's extra JSON
4. Change the passphrase secret revision and verify the coordinator picks up the change and updates the Airflow connection

## Notes for Reviewers (optional)

Airflow's git connection extras use `private_key_passphrase` (not `passphrase`) and `ssh_port` (string) — these map to the fields documented at https://airflow.apache.org/docs/apache-airflow-providers-git/stable/connections/git.html.

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated