### PR TITLE
[WF-405] updated airflow-coordinator blockedStatus message

### DIFF
--- a/terraform/justfile
+++ b/terraform/justfile
@@ -64,4 +64,4 @@ test:
 
     just apply "./test/test.tfvars"
 
-    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Missing integration with postgres'))"
+    juju wait-for model terraform --query="forEach(units, unit => (unit.workload-status == 'blocked' && unit.workload-message == 'Waiting for fernet key secret configuration'))"


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Currently the `just` target waits for airflow-coordinator to be blocked on terraform apply  with message `Missing integration with postgres` Refer [here](https://github.com/canonical/airflow-coordinator-k8s-operator/blob/feat/support-ssh-passphrase-and-port/terraform/justfile#L67C131-L67C164)
This PR updates the message to  `Waiting for fernet key secret configuration`
<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
