### PR TITLE
[WF-379] Add git_default connection upon first unauthenticated git dag bundle

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -400,8 +400,7 @@ class AirflowCoordinatorK8SOperatorCharm(ops.CharmBase):
             erroneous_relation_ids = [
                 str(relation.id)
                 for relation in self._git_requires.relations
-                if relation.id not in self._git_requires.get_git_connection_information()
-                and relation.data[relation.app]
+                if relation.id not in self.git_relation_connections and relation.data[relation.app]
             ]
 
             if erroneous_relation_ids:

--- a/src/config_generator.py
+++ b/src/config_generator.py
@@ -202,7 +202,7 @@ class AirflowConfigGenerator:
 
         git_dag_bundles = [
             self._dag_bundle_for_git_connection(relation_id, git_provider_model)
-            for relation_id, git_provider_model in self._charm._git_requires.get_git_connection_information().items()  # noqa: E501
+            for relation_id, git_provider_model in self._charm.git_relation_connections.items()  # noqa: E501
         ]
 
         if not s3_dag_bundles and not git_dag_bundles:

--- a/src/connection_manager.py
+++ b/src/connection_manager.py
@@ -233,21 +233,23 @@ class AirflowConnectionManager:
         """Create or update git connections that have changed."""
         airflow_connection_ids = [connection.conn_id for connection in self.airflow_connections]
 
+        if "git_default" not in self.airflow_connections and self._charm.git_relation_connections:
+            logger.info("Adding `git_default` Airflow connection")
+
+            self._charm._command_executor.add_airflow_git_connection(
+                "git_default",
+                git.GitProviderModel(
+                    repository_url="https://github.com",
+                ),
+            )
+
+            self.refresh()
+
         for (
             relation_id,
             git_provider_model,
-        ) in self._charm._git_requires.get_git_connection_information().items():
+        ) in self._charm.git_relation_connections.items():
             if git_provider_model.authentication_method is None:
-                if "git_default" not in self.airflow_connections:
-                    logger.info("Adding git_default Airflow connection")
-
-                    self._charm._command_executor.add_airflow_git_connection(
-                        "git_default",
-                        git.GitProviderModel(
-                            repository_url="https://github.com",
-                        ),
-                    )
-
                 continue
 
             connection_id = f"git_relation_{relation_id}_connection"
@@ -284,8 +286,11 @@ class AirflowConnectionManager:
         for airflow_connection_id in [
             connection.conn_id
             for connection in self.airflow_connections
-            if connection.conn_id.startswith("s3_relation_")
-            or connection.conn_id.startswith("git_relation_")
+            if (
+                connection.conn_id.startswith("s3_relation_")
+                or connection.conn_id.startswith("git_relation_")
+            )
+            and connection.conn_id != "git_default"
         ]:
             if (
                 airflow_connection_id not in s3_relation_connection_ids

--- a/src/connection_manager.py
+++ b/src/connection_manager.py
@@ -238,10 +238,16 @@ class AirflowConnectionManager:
             git_provider_model,
         ) in self._charm._git_requires.get_git_connection_information().items():
             if git_provider_model.authentication_method is None:
-                logger.debug(
-                    f"Skipping Airflow connection creation for relation {relation_id}"
-                    " since it has no authentication"
-                )
+                if "git_default" not in self.airflow_connections:
+                    logger.info("Adding git_default Airflow connection")
+
+                    self._charm._command_executor.add_airflow_git_connection(
+                        "git_default",
+                        git.GitProviderModel(
+                            repository_url="https://github.com",
+                        ),
+                    )
+
                 continue
 
             connection_id = f"git_relation_{relation_id}_connection"

--- a/src/connection_manager.py
+++ b/src/connection_manager.py
@@ -3,7 +3,6 @@
 
 """Airflow connection management abstraction for Airflow Coordinator charm."""
 
-import dataclasses
 import functools
 import json
 import logging
@@ -12,6 +11,7 @@ import typing
 import charms.git_integrator.v0.git as git
 import object_storage
 import ops
+import pydantic
 
 import constants
 
@@ -22,7 +22,7 @@ class InvalidAirflowConnectionsError(Exception):
     """Custom exception raised when `airflow connections list` output is invalid."""
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass
 class AirflowConnection:
     """Dataclass representing an Airflow connection."""
 
@@ -33,7 +33,7 @@ class AirflowConnection:
     login: str | None = None
     password: str | None = None
 
-    extra_dejson: dict = dataclasses.field(default_factory=dict)
+    extra_dejson: dict = pydantic.Field(default_factory=dict)
 
     @classmethod
     def from_airflow_connections_list_output(cls, data: list[dict]):
@@ -49,7 +49,7 @@ class AirflowConnection:
         ]
 
 
-@dataclasses.dataclass
+@pydantic.dataclasses.dataclass
 class S3ConnectionInfo:
     """S3 Connection Info extracted from object_storage lib."""
 
@@ -62,7 +62,7 @@ class S3ConnectionInfo:
     path: typing.Optional[str] = None
     s3_api_version: typing.Optional[str] = None
     s3_uri_style: typing.Optional[str] = None
-    tls_ca_chain: list[str] = dataclasses.field(default_factory=list)
+    tls_ca_chain: list[str] = pydantic.Field(default_factory=list)
     delete_older_than_days: typing.Optional[str] = None
 
     @classmethod
@@ -77,6 +77,12 @@ class S3ConnectionInfo:
             return None
 
         normalized_data = {key.replace("-", "_"): value for key, value in data.items()}
+
+        if isinstance(normalized_data["tls_ca_chain"], str):
+            try:
+                normalized_data["tls_ca_chain"] = json.loads(normalized_data["tls_ca_chain"])
+            except Exception:
+                pass
 
         return cls(**normalized_data)
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1073,7 +1073,30 @@ class TestDagBundles:
                 }.items()
             ]
 
-        assert mock_command_executor["add_airflow_git_connection"].call_count == 2
+        expected_add_airflow_connection_calls = [
+            unittest.mock.call(
+                "git_default",
+                git.GitProviderModel(repository_url="https://github.com"),
+            ),
+            unittest.mock.call(
+                f"git_relation_{git_credentials_relation.id}_connection",
+                git.GitProviderModel(
+                    **git_credentials_relation.remote_app_data,
+                    credentials_personal_access_token="test-token",
+                ),
+            ),
+            unittest.mock.call(
+                f"git_relation_{git_ssh_relation.id}_connection",
+                git.GitProviderModel(
+                    **git_ssh_relation.remote_app_data,
+                    ssh_private_key="test-key",
+                ),
+            ),
+        ]
+
+        assert sorted(mock_command_executor["add_airflow_git_connection"].mock_calls) == sorted(
+            expected_add_airflow_connection_calls
+        )
         mock_command_executor["add_airflow_git_connection"].reset_mock()
 
         modified_git_unauthenticated_relation = ops.testing.Relation(
@@ -1244,7 +1267,30 @@ class TestDagBundles:
                 }.items()
             ]
 
-        assert mock_command_executor["add_airflow_git_connection"].call_count == 2
+        expected_add_airflow_connection_calls = [
+            unittest.mock.call(
+                "git_default",
+                git.GitProviderModel(repository_url="https://github.com"),
+            ),
+            unittest.mock.call(
+                f"git_relation_{git_credentials_relation.id}_connection",
+                git.GitProviderModel(
+                    **git_credentials_relation.remote_app_data,
+                    credentials_personal_access_token="test-token",
+                ),
+            ),
+            unittest.mock.call(
+                f"git_relation_{git_ssh_relation.id}_connection",
+                git.GitProviderModel(
+                    **git_ssh_relation.remote_app_data,
+                    ssh_private_key="test-key",
+                ),
+            ),
+        ]
+
+        assert sorted(mock_command_executor["add_airflow_git_connection"].mock_calls) == sorted(
+            expected_add_airflow_connection_calls
+        )
         mock_command_executor["add_airflow_git_connection"].reset_mock()
 
         relations_with_removed_git_relation = [

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1203,6 +1203,11 @@ class TestDagBundles:
                     "strict_host_key_checking": "true",
                 },
             },
+            {
+                "conn_id": "git_default",
+                "conn_type": "git",
+                "host": "https://github.com",
+            },
         ]
 
         mock_command_executor["list_airflow_connections"].side_effect = [
@@ -1214,14 +1219,21 @@ class TestDagBundles:
             ),
             command_executor.CommandExecutionResult(
                 success=True,
-                stdout=json.dumps(airflow_connections),
-                parsed_stdout=airflow_connections,
+                stdout=json.dumps(airflow_connections[3:]),
+                parsed_stdout=airflow_connections[3:],
                 stderr="",
                 return_code=0,
             ),
             command_executor.CommandExecutionResult(
                 success=True,
-                stdout=json.dumps(airflow_connections),
+                stdout=json.dumps(airflow_connections[1:]),
+                parsed_stdout=airflow_connections[1:],
+                stderr="",
+                return_code=0,
+            ),
+            command_executor.CommandExecutionResult(
+                success=True,
+                stdout=json.dumps(airflow_connections[1:]),
                 parsed_stdout=airflow_connections[1:],
                 stderr="",
                 return_code=0,
@@ -1332,7 +1344,10 @@ class TestDagBundles:
                 },
             ]
 
-        mock_command_executor["add_airflow_git_connection"].assert_not_called()
+        mock_command_executor["add_airflow_git_connection"].assert_called_once_with(
+            "git_default",
+            git.GitProviderModel(repository_url="https://github.com"),
+        )
         mock_command_executor["delete_airflow_connection"].mock_calls == [
             unittest.mock.call(f"git_relation_{git_credentials_relation.id}_connection"),
         ]

--- a/tests/unit/test_connection_manager.py
+++ b/tests/unit/test_connection_manager.py
@@ -311,13 +311,26 @@ class TestConnectionManager:
             if expect_updates:
                 mock_command_executor["delete_airflow_connection"].assert_not_called()
 
-                mock_command_executor["add_airflow_git_connection"].assert_called_once_with(
-                    connection_id,
-                    valid_git_provider_model,
+                assert sorted(
+                    mock_command_executor["add_airflow_git_connection"].mock_calls
+                ) == sorted(
+                    [
+                        unittest.mock.call(
+                            "git_default",
+                            git.GitProviderModel(repository_url="https://github.com"),
+                        ),
+                        unittest.mock.call(
+                            connection_id,
+                            valid_git_provider_model,
+                        ),
+                    ]
                 )
             else:
                 mock_command_executor["delete_airflow_connection"].assert_not_called()
-                mock_command_executor["add_airflow_git_connection"].assert_not_called()
+                mock_command_executor["add_airflow_git_connection"].assert_called_once_with(
+                    "git_default",
+                    git.GitProviderModel(repository_url="https://github.com"),
+                )
 
     def test_delete_stale_connections(
         self, airflow_connection_manager, valid_list_airflow_connections_output


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
When an unauthenticated git dag bundle is used, the `git_conn_id` is omitted in the dag bundle config. This results in Airflow seeking a `git_default` connection (the fallback default), and DAG processor logs an error if this connection does not exist.

This PR add the `git_default` connection if it does not already exist upon the first encounter of an unauthenticated git dag bundle.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->
Closes #43 
---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
