### PR TITLE
chore: pin image sha instead of tag

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -46,7 +46,7 @@ resources:
   airflow-coordinator-image:
     type: oci-image
     description: Airflow workload container for running commands
-    upstream-source: ubuntu/airflow:3.1-24.04_edge
+    upstream-source: ubuntu/airflow@sha256:0a025779768549281c662b9e01589ce94e4a9d69f0ffd5040fd039104e3c0d59
 
 provides:
   airflow-coordinator:


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

Pinning the image digest hash rather than the image tag guarantees reproducibility and consistency across revisions.

Relates to https://github.com/canonical/airflow-core-operators/issues/31

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->



Just verify the hash is the same as the latest published https://hub.docker.com/r/ubuntu/airflow/tags
Alternatively, you can pull the docker image and inspect it.

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
