### PR TITLE
Avoid setting core.default_impersonation config in airflow.cfg

### DIFF
--- a/src/templates/airflow_config.j2
+++ b/src/templates/airflow_config.j2
@@ -4,7 +4,6 @@ load_examples = False
 fernet_key = {{ core__fernet_key }}
 dagbag_import_error_tracebacks = False
 check_migrations = False
-default_impersonation = ubuntu
 
 [database]
 {% if render_sensitive_data %}sql_alchemy_conn = {{ database__sql_alchemy_conn }}{% endif %}

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1609,7 +1609,6 @@ class TestAirflowConfigurability:
             assert parsed["core"]["dagbag_import_error_tracebacks"] == "False"
             assert parsed["core"]["check_migrations"] == "False"
             assert parsed["core"]["load_examples"] == "False"
-            assert parsed["core"]["default_impersonation"] == "ubuntu"
 
             assert parsed["scheduler"]["enable_healthcheck"] == "True"
 


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
We updated the default `core.default_impersonation = ubuntu` in the generated airflow.cfg file. As a result, we run into the following error on the worker pod (where tasks are executed when using K8s executor):

```
{"timestamp":"2026-05-05T10:00:41.924144Z","level":"info","event":"Running command","command":["sudo","-E","-H","-u","ubuntu","/ho
me/airflow/.local/bin/python","-c","from airflow.sdk.execution_time.task_runner import main; main()"],"logger":"task","filename":"
supervisor.py","lineno":1806}
{"timestamp":"2026-05-05T10:00:41.934729Z","level":"error","event":"sudo: unable to execute /home/airflow/.local/bin/python: Permi
ssion denied","logger":"task.stderr","filename":"supervisor.py","lineno":1821}
{"timestamp":"2026-05-05T10:00:41.946692Z","level":"info","event":"Task finished","task_instance_id":"019df794-6e75-75bd-959d-6612
2d98cb14","exit_code":1,"duration":5.000646583008347,"final_state":"failed","logger":"supervisor","filename":"supervisor.py","line
no":1995}
```

We cannot assume that the worker pod will have an `ubuntu` user + we run into issues even when the image used for worker pods has an ubuntu user added.

This PR removes the configuration to avoid this issue.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
