### PR TITLE
[WF-414] Update airflow coordinator charm lib to support optional distribution of webserver config

### DIFF
--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -275,16 +275,16 @@ class AirflowCoordinatorProviderModel(data_interfaces.BaseCommonModel):
     # (str from coordinator) and structured config dicts (from executor, deserialized
     # by data_interfaces' get_data). This will change when we refactor the library
     # to a much more generic one.
-    config_template: str | dict | None = None
-    kubernetes_executor_pod_spec: str | None = None
-    webserver_config_template: str | None = None
+    config_template: typing.Optional[str | dict] = None
+    kubernetes_executor_pod_spec: typing.Optional[str] = None
+    webserver_config_template: typing.Optional[str] = None
     sensitive_data: SensitiveDataSecretStr = None
-    secret_sensitive_data: data_interfaces.SecretString | None = None
+    secret_sensitive_data: typing.Optional[data_interfaces.SecretString] = None
 
-    validation_failures: str | None = None
+    validation_failures: typing.Optional[str] = None
 
     # CA chains for Airflow connections
-    tls_ca_chains: dict[str, str] | None = None
+    tls_ca_chains: typing.Optional[dict[str, str]] = None
 
     # hack to enable databag diff computation with data_interfaces v1 charm lib
     request_id: str = pydantic.Field(default="fixed_request_id", exclude=True)
@@ -322,8 +322,8 @@ class AirflowCoordinatorEvent(ops.EventBase, typing.Generic[TAirflowCoordinatorM
         self,
         handle: ops.Handle,
         relation: ops.Relation,
-        app: ops.Application | None,
-        unit: ops.Unit | None,
+        app: typing.Optional[ops.Application],
+        unit: typing.Optional[ops.Unit],
         content: TAirflowCoordinatorModels,
     ):
         super().__init__(handle)
@@ -666,7 +666,7 @@ class AirflowCoordinatorProviderEventHandler(
         self,
         config_template: str = None,
         kubernetes_executor_pod_spec: str = None,
-        webserver_config_template: str = None,
+        webserver_config_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
         tls_ca_chains: dict[str, str] = {},
     ):

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -90,6 +90,12 @@ the pebble workload container
 to render and write the k8s executor pod spec
 8. `write_kubernetes_executor_pod_spec(filepath)`: renders and writes the k8s
 executor pod spec into the pebble workload container
+9. `can_write_webserver_config`: all prerequisities met to be able to render and
+write the webserver config file
+10. `webserver_config_needs_update(filepath)`: if the webserver config file in
+the relation has drifted from the contents of file on the workload container
+11. `write_webserver_config(filepath, user, group)`: write the webserver config
+file contents to the workload container
 
 `AirflowCoordinatorCoreRequires` will invoke the provided `callback` when:
 - the coordinator charm shares validation failures for all related core charms
@@ -165,7 +171,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 7
+LIBPATCH = 8
 
 
 logger = logging.getLogger(__name__)
@@ -271,6 +277,7 @@ class AirflowCoordinatorProviderModel(data_interfaces.BaseCommonModel):
     # to a much more generic one.
     config_template: str | dict | None = None
     kubernetes_executor_pod_spec: str | None = None
+    webserver_config_template: str | None = None
     sensitive_data: SensitiveDataSecretStr = None
     secret_sensitive_data: data_interfaces.SecretString | None = None
 
@@ -659,6 +666,7 @@ class AirflowCoordinatorProviderEventHandler(
         self,
         config_template: str = None,
         kubernetes_executor_pod_spec: str = None,
+        webserver_config_template: str = None,
         sensitive_data: dict[str, str] = {},
         tls_ca_chains: dict[str, str] = {},
     ):
@@ -685,6 +693,7 @@ class AirflowCoordinatorProviderEventHandler(
                         model.config_template = config_template
 
                     model.kubernetes_executor_pod_spec = kubernetes_executor_pod_spec
+                    model.webserver_config_template = webserver_config_template
 
                     if sensitive_data:
                         model.sensitive_data = json.dumps(sensitive_data)
@@ -699,6 +708,7 @@ class AirflowCoordinatorProviderEventHandler(
                 model = AirflowCoordinatorProviderModel(
                     config_template=config_template,
                     kubernetes_executor_pod_spec=kubernetes_executor_pod_spec,
+                    webserver_config_template=webserver_config_template,
                     sensitive_data=json.dumps(sensitive_data),
                     tls_ca_chains=tls_ca_chains,
                 )
@@ -726,6 +736,7 @@ class AirflowCoordinatorProviderEventHandler(
 
                     model.config_template = None
                     model.kubernetes_executor_pod_spec = None
+                    model.webserver_config_template = None
                     # a truthy value assigned to avoid underlying secret from being deleted
                     model.sensitive_data = json.dumps({})
 
@@ -1007,6 +1018,46 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
         )
 
     @property
+    def can_write_webserver_config(self) -> bool:
+        """Indicate if it is safe to write webserver_config.py to the workload container.
+
+        Returns True when pebble is reachable, the relation is ready (no validation
+        errors), and the coordinator has shared a webserver config template and
+        sensitive data.
+        """
+        if not self._workload_container.can_connect():
+            return False
+        content = self._requirer_handler.provider_content
+        return bool(
+            self._ready
+            and content
+            and content.webserver_config_template
+            and content.sensitive_data
+        )
+
+    def webserver_config_needs_update(self, filepath: str) -> bool:
+        """Check whether the rendered webserver config differs from the file on disk."""
+        provider_content = self._requirer_handler.provider_content
+        rendered = jinja2.Template(provider_content.webserver_config_template).render(
+            **json.loads(provider_content.sensitive_data)
+        )
+
+        if self._workload_container.exists(filepath):
+            on_disk = self._workload_container.pull(filepath).read()
+        else:
+            on_disk = None
+
+        return on_disk != rendered
+
+    def write_webserver_config(self, filepath: str, user: str, group: str) -> None:
+        """Render and write webserver_config.py in the workload container."""
+        provider_content = self._requirer_handler.provider_content
+        rendered = jinja2.Template(provider_content.webserver_config_template).render(
+            **json.loads(provider_content.sensitive_data)
+        )
+        self._workload_container.push(filepath, rendered, user=user, group=group, make_dirs=True)
+
+    @property
     def can_write_tls_ca_chain(self) -> bool:
         """Indicate if there exist tls ca chains to write to workload container.
 
@@ -1185,6 +1236,7 @@ class AirflowCoordinatorProvides(ops.Object):
         self,
         config_template: typing.Optional[str] = None,
         k8s_executor_pod_spec_template: typing.Optional[str] = None,
+        webserver_config_template: typing.Optional[str] = None,
         sensitive_data: dict[str, str] = {},
         tls_ca_chains: dict[str, str] = {},
     ) -> None:
@@ -1193,6 +1245,7 @@ class AirflowCoordinatorProvides(ops.Object):
         Args:
             config_template: Airflow config as a Jinja2 template string.
             k8s_executor_pod_spec_template: (optional) K8s executor pod spec template.
+            webserver_config_template: (optional) Webserver config template for FAB OAuth.
             sensitive_data: sensitive data to render config of k8s executor pod
                 spec jinja templates with.
             tls_ca_chains: mapping from filename to tls ca chain file contents
@@ -1200,6 +1253,7 @@ class AirflowCoordinatorProvides(ops.Object):
         self._provider_handler.update_content(
             config_template=config_template,
             kubernetes_executor_pod_spec=k8s_executor_pod_spec_template,
+            webserver_config_template=webserver_config_template,
             sensitive_data=sensitive_data,
             tls_ca_chains=tls_ca_chains,
         )

--- a/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
+++ b/lib/charms/airflow_coordinator_k8s/v0/airflow_coordinator.py
@@ -1035,27 +1035,32 @@ class AirflowCoordinatorCoreRequires(AirflowCoordinatorRequires):
             and content.sensitive_data
         )
 
-    def webserver_config_needs_update(self, filepath: str) -> bool:
-        """Check whether the rendered webserver config differs from the file on disk."""
+    @property
+    def _webserver_config_from_relation(self) -> str:
+        """Render the webserver_config.py."""
         provider_content = self._requirer_handler.provider_content
-        rendered = jinja2.Template(provider_content.webserver_config_template).render(
+
+        return jinja2.Template(provider_content.webserver_config_template).render(
             **json.loads(provider_content.sensitive_data)
         )
 
+    def webserver_config_needs_update(self, filepath: str) -> bool:
+        """Check if webserver config file needs to be updated on workload container.
+
+        Return True if the rendered webserver config differs from the file on disk; False otherwise
+        """
         if self._workload_container.exists(filepath):
             on_disk = self._workload_container.pull(filepath).read()
         else:
             on_disk = None
 
-        return on_disk != rendered
+        return on_disk != self._webserver_config_from_relation
 
     def write_webserver_config(self, filepath: str, user: str, group: str) -> None:
         """Render and write webserver_config.py in the workload container."""
-        provider_content = self._requirer_handler.provider_content
-        rendered = jinja2.Template(provider_content.webserver_config_template).render(
-            **json.loads(provider_content.sensitive_data)
+        self._workload_container.push(
+            filepath, self._webserver_config_from_relation, user=user, group=group, make_dirs=True
         )
-        self._workload_container.push(filepath, rendered, user=user, group=group, make_dirs=True)
 
     @property
     def can_write_tls_ca_chain(self) -> bool:

--- a/src/config_generator.py
+++ b/src/config_generator.py
@@ -211,7 +211,7 @@ class AirflowConfigGenerator:
         return {
             "dag_processor": {
                 "dag_bundle_config_list": json.dumps(
-                    s3_dag_bundles + git_dag_bundles,
+                    sorted(s3_dag_bundles + git_dag_bundles, key=lambda element: element["name"]),
                     indent=4,
                 ),
             },

--- a/tests/unit/test_airflow_coordinator.py
+++ b/tests/unit/test_airflow_coordinator.py
@@ -1138,7 +1138,7 @@ class TestAirflowCoordinatorCoreRequires:
             ),
         ],
     )
-    def test_webserver_config_needs_update_unchanged_contents(
+    def test_webserver_config_needs_update(
         self,
         application_context,
         application_state,

--- a/tests/unit/test_airflow_coordinator.py
+++ b/tests/unit/test_airflow_coordinator.py
@@ -5,6 +5,7 @@
 
 import abc
 import dataclasses
+import io
 import json
 import logging
 import pathlib
@@ -13,6 +14,7 @@ import typing
 import unittest
 
 import charms.airflow_coordinator_k8s.v0.airflow_coordinator as airflow_coordinator
+import jinja2
 import ops
 import ops.testing
 import pytest
@@ -184,6 +186,7 @@ def valid_relation_data(coordinator_relation_secret):
                 "/file2": "chain2\nchain3",
             }
         ),
+        "webserver-config-template": "test-webserver-config: {{ secret }}",
     }
 
 
@@ -1033,6 +1036,159 @@ class TestAirflowCoordinatorCoreRequires:
                     ),
                 ]
 
+    def test_can_write_webserver_config_container_not_connectable(
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
+        application_workload_container,
+    ):
+        container_not_ready = dataclasses.replace(
+            application_workload_container, can_connect=False
+        )
+        state = dataclasses.replace(application_state, containers=[container_not_ready])
+
+        with application_context(
+            application_context.on.relation_changed(application_airflow_coordinator_relation),
+            state,
+        ) as manager:
+            manager.run()
+            assert not manager.charm.requirer.can_write_webserver_config
+
+    def test_can_write_webserver_config_provider_data_not_present(
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
+        valid_relation_data,
+    ):
+        relation_data_without_webserver_config = valid_relation_data
+        relation_data_without_webserver_config.pop("webserver-config-template", None)
+
+        relation_without_webserver_config = dataclasses.replace(
+            application_airflow_coordinator_relation,
+            remote_app_data=relation_data_without_webserver_config,
+        )
+
+        state_without_webserver_config = dataclasses.replace(
+            application_state, relations=[relation_without_webserver_config]
+        )
+
+        with application_context(
+            application_context.on.relation_changed(relation_without_webserver_config),
+            state_without_webserver_config,
+        ) as manager:
+            manager.run()
+            assert not manager.charm.requirer.can_write_webserver_config
+
+    @pytest.mark.parametrize(
+        [
+            "disk_file_exists",
+            "disk_content",
+            "relation_content",
+            "update_required",
+            "expected_error",
+        ],
+        [
+            pytest.param(
+                False, None, None, False, False, id="no_disk_content_no_relation_content"
+            ),
+            pytest.param(
+                False, None, "content1", True, False, id="no_disk_content_relation_content_exists"
+            ),
+            pytest.param(
+                True,
+                io.StringIO("content1"),
+                "content1",
+                False,
+                False,
+                id="disk_and_relation_content_same",
+            ),
+            pytest.param(
+                True,
+                io.StringIO("content1"),
+                "content2",
+                True,
+                False,
+                id="relation_content_different_than_disk",
+            ),
+            pytest.param(
+                True,
+                io.StringIO("content1"),
+                None,
+                True,
+                False,
+                id="disk_content_no_relation_content",
+            ),
+            pytest.param(
+                True,
+                ops.pebble.PathError("test", "test error"),
+                "content2",
+                None,
+                ops.pebble.PathError,
+                id="error_retrieving_disk_content",
+            ),
+            pytest.param(
+                True,
+                "content1",
+                jinja2.exceptions.TemplateSyntaxError("test-error", lineno=1),
+                None,
+                jinja2.exceptions.TemplateSyntaxError,
+                id="error_rendering_relation_content",
+            ),
+        ],
+    )
+    def test_webserver_config_needs_update_unchanged_contents(
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
+        disk_file_exists,
+        disk_content,
+        relation_content,
+        update_required,
+        expected_error,
+    ):
+        with (
+            unittest.mock.patch("ops.Container.exists", return_value=disk_file_exists),
+            unittest.mock.patch("ops.Container.pull", side_effect=[disk_content]),
+            unittest.mock.patch.object(jinja2.Template, "render", side_effect=[relation_content]),
+        ):
+            with application_context(
+                application_context.on.relation_changed(application_airflow_coordinator_relation),
+                application_state,
+            ) as manager:
+                if expected_error:
+                    with pytest.raises(expected_error):
+                        manager.charm.requirer.webserver_config_needs_update("/test/file")
+                else:
+                    assert (
+                        manager.charm.requirer.webserver_config_needs_update("/test/file")
+                        == update_required
+                    )
+
+    def test_wrtie_webserver_config(
+        self,
+        application_context,
+        application_state,
+        application_airflow_coordinator_relation,
+    ):
+        with (
+            unittest.mock.patch.object(
+                jinja2.Template, "render", side_effect=["relation-content"]
+            ),
+            unittest.mock.patch("ops.Container.push") as mock_push,
+        ):
+            with application_context(
+                application_context.on.relation_changed(application_airflow_coordinator_relation),
+                application_state,
+            ) as manager:
+                manager.charm.requirer.write_webserver_config("/test/file", "ubuntu", "ubuntu")
+
+                mock_push.assert_called_once_with(
+                    "/test/file", "relation-content", user="ubuntu", group="ubuntu", make_dirs=True
+                )
+
 
 class TestAirflowCoordinatorProvides:
     def get_juju_log_line(self, log_level: str, event: ops.EventBase):
@@ -1225,6 +1381,7 @@ class TestAirflowCoordinatorProvides:
                     "secret": "s3cret",
                 },
                 "tls_ca_chains": tls_ca_chains,
+                "webserver_config_template": "test-webserver-config-template",
             }
 
             assert manager.charm.provider.set_airflow_config(**airflow_config_params) is None
@@ -1257,3 +1414,8 @@ class TestAirflowCoordinatorProvides:
                 }
 
                 assert relation.local_app_data["tls-ca-chains"] == json.dumps(tls_ca_chains)
+
+                assert (
+                    relation.local_app_data["webserver-config-template"]
+                    == airflow_config_params["webserver_config_template"]
+                )

--- a/tests/unit/test_airflow_coordinator.py
+++ b/tests/unit/test_airflow_coordinator.py
@@ -1130,7 +1130,7 @@ class TestAirflowCoordinatorCoreRequires:
             ),
             pytest.param(
                 True,
-                "content1",
+                io.StringIO("content1"),
                 jinja2.exceptions.TemplateSyntaxError("test-error", lineno=1),
                 None,
                 jinja2.exceptions.TemplateSyntaxError,
@@ -1151,7 +1151,7 @@ class TestAirflowCoordinatorCoreRequires:
     ):
         with (
             unittest.mock.patch("ops.Container.exists", return_value=disk_file_exists),
-            unittest.mock.patch("ops.Container.pull", side_effect=[disk_content]),
+            unittest.mock.patch.object(ops.Container, "pull", side_effect=[disk_content]),
             unittest.mock.patch.object(jinja2.Template, "render", side_effect=[relation_content]),
         ):
             with application_context(
@@ -1167,7 +1167,7 @@ class TestAirflowCoordinatorCoreRequires:
                         == update_required
                     )
 
-    def test_wrtie_webserver_config(
+    def test_write_webserver_config(
         self,
         application_context,
         application_state,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -531,10 +531,12 @@ class TestDagBundles:
                         "prefix": connection_info["path"],
                     },
                 }
-                for relation_id, connection_info in {
-                    s3_integrator_relation.id: s3_integrator_relation.remote_app_data,
-                    s3_integrator_relation2.id: s3_integrator_relation2.remote_app_data,
-                }.items()
+                for relation_id, connection_info in sorted(
+                    {
+                        s3_integrator_relation.id: s3_integrator_relation.remote_app_data,
+                        s3_integrator_relation2.id: s3_integrator_relation2.remote_app_data,
+                    }.items()
+                )
             ]
 
     def test_valid_s3_relations_non_leader(self, context, state_without_git):


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Implement changes to the airflow coordinator charm lib to optionally distribute the webserver config file (according to spec [WF-024 - Airflow Identity Integration](https://docs.google.com/document/d/16mzvH8-WNAC1Xu_WQrR89JlOQZmmS4psmW9l1vkiCAs/edit?usp=sharing) )

Changes include:
- AirflowCoordinatorProviderModel: adds optional field `webserver_config_template`
- AirflowCoordinatorProvides.set_airflow_config() accepts optional kwarg `webserver_config_template`
- AirflowCoordinatorCoreRequires: implements 3 methods to see if (1) webserver config can be written, (2) webserver config in workload containers needs update and (3) write webserver config file to workload container
- Associated unit tests for the modified charm lib methods

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
