### PR TITLE
[WF-456] Surface the new oauth relation endpoint in the terraform module

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -11,8 +11,9 @@ output "provides" {
 
 output "requires" {
   value = {
-    postgres                = "postgres"
-    airflow_api_server      = "airflow-api-server"
+    postgres                    = "postgres"
+    airflow_api_server          = "airflow-api-server"
     airflow_kubernetes_executor = "airflow-kubernetes-executor-config"
+    oauth                       = "oauth"
   }
 }


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->
Add the `requires.oauth` relation endpoint in the output of the charm's terraform module.

This will allow users of the charmed-airflow-solution module to get the coordinator's oauth endpoint and create an integration with the oauth endpoint of the hydra charm in the canonical identity platform solution module.  

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [ ] Unit tests added or updated
- [ ] Integration tests added or updated
- [ ] Documentation updated
