### PR TITLE
test: correct the relation endpoint name

### DIFF
--- a/tests/unit/test_airflow_coordinator.py
+++ b/tests/unit/test_airflow_coordinator.py
@@ -1223,7 +1223,7 @@ class TestAirflowCoordinatorProvides:
 
         with coordinator_waiting_context(
             coordinator_waiting_context.on.relation_changed(
-                state.get_relations("airflow_coordinator")[0]
+                state.get_relations("airflow-coordinator")[0]
             ),
             state,
         ) as manager:


### PR DESCRIPTION
## Description
<!-- Summary of the changes in this PR -->

This PR corrects the name of the relation endpoint in one test.

<!-- Reference the issue this PR addresses (e.g., Closes #123) -->

---
## Testing instructions
<!-- Steps to manually test the changes and the expected results, only if applicable -->
<!-- Example:
1. Build charm
2. Configure X with abc value
3. Integrate with Y charm
-->

Run the tests, with latest ops and with the https://github.com/canonical/operator/pull/2570 branch (or ops main, if that PR has merged).

## Notes for Reviewers (optional)
<!-- Any specific areas to focus on, known issues, or extra context -->

---
## Checklist (all that apply)
- [x] Unit tests added or updated
- [ ] ~Integration tests added or updated~
- [ ] ~Documentation updated~
